### PR TITLE
Fix tmux base-index window targeting

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -10,6 +10,9 @@ cleanup() {
   tmux list-sessions -F '#{session_name}' 2>/dev/null | grep "^${TEST_PREFIX}" | while read -r session; do
     tmux kill-session -t "$session" 2>/dev/null || true
   done
+  if [ -d "/tmp/${TEST_PREFIX}_base_index_sock" ]; then
+    env -u TMUX TMUX_TMPDIR="/tmp/${TEST_PREFIX}_base_index_sock" tmux kill-server >/dev/null 2>&1 || true
+  fi
   rm -rf "$TMP_DIR" "/tmp/${TEST_PREFIX}_base_index_sock"
 }
 trap cleanup EXIT

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -10,7 +10,7 @@ cleanup() {
   tmux list-sessions -F '#{session_name}' 2>/dev/null | grep "^${TEST_PREFIX}" | while read -r session; do
     tmux kill-session -t "$session" 2>/dev/null || true
   done
-  rm -rf "$TMP_DIR"
+  rm -rf "$TMP_DIR" "/tmp/${TEST_PREFIX}_base_index_sock"
 }
 trap cleanup EXIT
 
@@ -45,7 +45,7 @@ run_expect_failure() {
   printf '%s' "$output"
 }
 
-echo "1..7"
+echo "1..8"
 
 output=$(run_expect_success "$TMUXIFY" --help)
 assert_contains "$output" "--dry-run"
@@ -126,7 +126,35 @@ active_pane=$(tmux display-message -p -t "${TEST_PREFIX}_nested" '#{pane_index}'
 [[ "$active_pane" == "0" ]] || fail "expected editor pane to be active, got pane $active_pane"
 echo "ok 6 - detached nested session creates expected panes and focus"
 
+cat > "$TMP_DIR/base-index.yml" <<YAML
+session:
+  name: ${TEST_PREFIX}_base_index
+  initial_focus: editor
+layout:
+  type: horizontal
+  splits:
+    - id: editor
+      size: 50%
+    - id: shell
+      size: 50%
+YAML
+base_index_sockdir="/tmp/${TEST_PREFIX}_base_index_sock"
+rm -rf "$base_index_sockdir"
+mkdir -p "$base_index_sockdir"
+env -u TMUX TMUX_TMPDIR="$base_index_sockdir" tmux new-session -d -s "${TEST_PREFIX}_keepalive"
+env -u TMUX TMUX_TMPDIR="$base_index_sockdir" tmux set-option -g base-index 1
+env -u TMUX TMUX_TMPDIR="$base_index_sockdir" tmux set-window-option -g pane-base-index 1
+run_expect_success env -u TMUX TMUX_TMPDIR="$base_index_sockdir" "$TMUXIFY" --file "$TMP_DIR/base-index.yml" --detach --no-commands >/dev/null
+window_index=$(env -u TMUX TMUX_TMPDIR="$base_index_sockdir" tmux list-windows -t "${TEST_PREFIX}_base_index" -F '#{window_index}')
+[[ "$window_index" == "1" ]] || fail "expected first window index 1 with base-index enabled, got $window_index"
+pane_count=$(env -u TMUX TMUX_TMPDIR="$base_index_sockdir" tmux list-panes -t "${TEST_PREFIX}_base_index" | wc -l | tr -d ' ')
+[[ "$pane_count" == "2" ]] || fail "expected 2 panes with base-index enabled, got $pane_count"
+pane_indices=$(env -u TMUX TMUX_TMPDIR="$base_index_sockdir" tmux list-panes -t "${TEST_PREFIX}_base_index" -F '#{pane_index}' | paste -sd, -)
+[[ "$pane_indices" == "1,2" ]] || fail "expected pane indices 1,2 with pane-base-index enabled, got $pane_indices"
+env -u TMUX TMUX_TMPDIR="$base_index_sockdir" tmux kill-server >/dev/null 2>&1 || true
+echo "ok 7 - detached session works with tmux base-index 1"
+
 while IFS= read -r example; do
   run_expect_success "$TMUXIFY" --dry-run --file "$example" >/dev/null
 done < <(find "$ROOT_DIR/examples/layouts" -type f -name '*.yml' -print | sort)
-echo "ok 7 - bundled examples validate"
+echo "ok 8 - bundled examples validate"

--- a/tmuxify
+++ b/tmuxify
@@ -561,8 +561,8 @@ create_default_layout() {
   info "Using default 4-pane layout."
   tmux_or_die tmux new-session -d -s "$session_name" -c "$WORKDIR" "nvim ."
   SESSION_CREATED=1
-  tmux_or_die tmux set-window-option -t "$session_name:0" aggressive-resize on
-  pane0=$(tmux display-message -t "$session_name:0.0" -p '#{pane_id}') || die "Failed to identify initial pane."
+  tmux_or_die tmux set-window-option -t "$session_name" aggressive-resize on
+  pane0=$(tmux display-message -t "$session_name" -p '#{pane_id}') || die "Failed to identify initial pane."
   pane1=$(tmux split-window -h -t "$pane0" -c "$WORKDIR" -P -F '#{pane_id}') || die "Failed to create default pane."
   apply_size horizontal "$pane0" "50%"
   pane2=$(tmux split-window -v -t "$pane1" -c "$WORKDIR" -P -F '#{pane_id}') || die "Failed to create default pane."
@@ -590,8 +590,8 @@ fi
 tmux_or_die tmux new-session -d -s "$session_name" -c "$WORKDIR"
 SESSION_CREATED=1
 info "Building layout from $CONFIG_FILE..."
-tmux_or_die tmux set-window-option -t "$session_name:0" aggressive-resize on
-root_pane=$(tmux display-message -t "$session_name:0.0" -p '#{pane_id}') || die "Failed to identify initial pane."
+tmux_or_die tmux set-window-option -t "$session_name" aggressive-resize on
+root_pane=$(tmux display-message -t "$session_name" -p '#{pane_id}') || die "Failed to identify initial pane."
 build_layout ".layout" "$root_pane"
 
 initial_focus=$(yq -r '.session.initial_focus // ""' "$CONFIG_FILE")


### PR DESCRIPTION
## Summary
- stop hard-coding window index 0 when configuring the newly created tmux session
- resolve the first pane via the session target so base-index and pane-base-index customizations work
- add an isolated regression test for tmux base-index 1 and pane-base-index 1

Fixes #1.

## Tests
- ./tests/run.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for tmux base-index and pane-base-index configurations to validate proper window indexing and pane behavior.

* **Bug Fixes**
  * Improved tmux window option application and pane ID discovery for enhanced compatibility with custom base-index session settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->