### PR TITLE
feat: add user config layout lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,16 @@ Configuration priority:
 
 1. `--file <path>` uses the specified YAML file.
 2. `.tmuxify.yml` in the current directory.
-3. Built-in default four-pane layout when no config exists.
+3. `${XDG_CONFIG_HOME:-~/.config}/tmuxify/layouts/default.yml` for a reusable user default.
+4. Built-in default four-pane layout when no config exists.
+
+Tmuxify reserves `${XDG_CONFIG_HOME:-~/.config}/tmuxify/` for user-level files. `tmuxify --update` creates the config folders and refreshes bundled examples under `layouts/examples/`. Put your reusable default layout at `layouts/default.yml`:
+
+```bash
+mkdir -p "${XDG_CONFIG_HOME:-$HOME/.config}/tmuxify/layouts"
+cp "${XDG_CONFIG_HOME:-$HOME/.config}/tmuxify/layouts/examples/golang-dev.yml" \
+  "${XDG_CONFIG_HOME:-$HOME/.config}/tmuxify/layouts/default.yml"
+```
 
 ## Command-line options
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -48,7 +48,7 @@ run_expect_failure() {
   printf '%s' "$output"
 }
 
-echo "1..9"
+echo "1..13"
 
 output=$(run_expect_success "$TMUXIFY" --help)
 assert_contains "$output" "--dry-run"
@@ -135,7 +135,8 @@ run_expect_success "$TMUXIFY" --file "$TMP_DIR/valid.yml" --detach --no-commands
 pane_count=$(tmux list-panes -t "${TEST_PREFIX}_nested" | wc -l | tr -d ' ')
 [[ "$pane_count" == "4" ]] || fail "expected 4 panes, got $pane_count"
 active_pane=$(tmux display-message -p -t "${TEST_PREFIX}_nested" '#{pane_index}')
-[[ "$active_pane" == "0" ]] || fail "expected editor pane to be active, got pane $active_pane"
+first_pane=$(tmux list-panes -t "${TEST_PREFIX}_nested" -F '#{pane_index}' | head -n 1)
+[[ "$active_pane" == "$first_pane" ]] || fail "expected editor pane to be active, got pane $active_pane"
 echo "ok 7 - detached nested session creates expected panes and focus"
 
 cat > "$TMP_DIR/base-index.yml" <<YAML
@@ -166,7 +167,80 @@ pane_indices=$(env -u TMUX TMUX_TMPDIR="$base_index_sockdir" tmux list-panes -t 
 env -u TMUX TMUX_TMPDIR="$base_index_sockdir" tmux kill-server >/dev/null 2>&1 || true
 echo "ok 8 - detached session works with tmux base-index 1"
 
+xdg_home="$TMP_DIR/xdg"
+global_project="$TMP_DIR/global-project"
+mkdir -p "$xdg_home/tmuxify/layouts" "$global_project"
+cat > "$xdg_home/tmuxify/layouts/default.yml" <<YAML
+session:
+  name: ${TEST_PREFIX}_global_default
+layout:
+  type: horizontal
+  splits:
+    - id: global_editor
+      size: 50%
+    - id: global_shell
+      size: 50%
+YAML
+output=$(run_expect_success env XDG_CONFIG_HOME="$xdg_home" bash -c 'cd "$1" && "$2" --dry-run' _ "$global_project" "$TMUXIFY")
+assert_contains "$output" "Using global default layout file"
+assert_contains "$output" "Session: ${TEST_PREFIX}_global_default"
+echo "ok 9 - global default layout is used when project config is absent"
+
+cat > "$global_project/.tmuxify.yml" <<YAML
+session:
+  name: ${TEST_PREFIX}_project_override
+layout:
+  type: horizontal
+  splits:
+    - id: project_editor
+      size: 50%
+    - id: project_shell
+      size: 50%
+YAML
+output=$(run_expect_success env XDG_CONFIG_HOME="$xdg_home" bash -c 'cd "$1" && "$2" --dry-run' _ "$global_project" "$TMUXIFY")
+assert_contains "$output" "Session: ${TEST_PREFIX}_project_override"
+echo "ok 10 - project layout overrides global default layout"
+
+cat > "$TMP_DIR/file-override.yml" <<YAML
+session:
+  name: ${TEST_PREFIX}_file_override
+layout:
+  type: horizontal
+  splits:
+    - id: file_editor
+      size: 50%
+    - id: file_shell
+      size: 50%
+YAML
+output=$(run_expect_success env XDG_CONFIG_HOME="$xdg_home" bash -c 'cd "$1" && "$2" --dry-run --file "$3"' _ "$global_project" "$TMUXIFY" "$TMP_DIR/file-override.yml")
+assert_contains "$output" "Session: ${TEST_PREFIX}_file_override"
+echo "ok 11 - explicit file layout overrides project and global layouts"
+
+update_install_dir="$TMP_DIR/update-install"
+update_xdg_home="$TMP_DIR/update-xdg"
+archive_root="$TMP_DIR/archive/tmuxify-main/examples/layouts"
+mkdir -p "$update_install_dir" "$archive_root"
+cp "$TMUXIFY" "$update_install_dir/tmuxify"
+chmod +x "$update_install_dir/tmuxify"
+cat > "$archive_root/example.yml" <<YAML
+session:
+  name: archive_example
+layout:
+  type: horizontal
+  splits:
+    - id: editor
+      size: 50%
+    - id: shell
+      size: 50%
+YAML
+(cd "$TMP_DIR/archive" && tar -czf "$TMP_DIR/examples.tar.gz" tmuxify-main)
+output=$(run_expect_success env XDG_CONFIG_HOME="$update_xdg_home" TMUXIFY_REPO_URL="file://$TMUXIFY" TMUXIFY_EXAMPLES_ARCHIVE_URL="file://$TMP_DIR/examples.tar.gz" "$update_install_dir/tmuxify" --update)
+assert_contains "$output" "Example layouts installed"
+[[ -d "$update_xdg_home/tmuxify/layouts" ]] || fail "expected update to create layouts directory"
+[[ -f "$update_xdg_home/tmuxify/layouts/examples/example.yml" ]] || fail "expected update to install example layouts"
+echo "ok 12 - update creates config folders and refreshes example layouts"
+
 while IFS= read -r example; do
   run_expect_success "$TMUXIFY" --dry-run --file "$example" >/dev/null
 done < <(find "$ROOT_DIR/examples/layouts" -type f -name '*.yml' -print | sort)
-echo "ok 9 - bundled examples validate"
+echo "ok 13 - bundled examples validate"

--- a/tmuxify
+++ b/tmuxify
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
 
 VERSION="2.5.3"
-REPO_URL="https://raw.githubusercontent.com/mustafamohsen/tmuxify/main/tmuxify"
+REPO_URL="${TMUXIFY_REPO_URL:-https://raw.githubusercontent.com/mustafamohsen/tmuxify/main/tmuxify}"
+EXAMPLES_ARCHIVE_URL="${TMUXIFY_EXAMPLES_ARCHIVE_URL:-https://github.com/mustafamohsen/tmuxify/archive/refs/heads/main.tar.gz}"
+CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
+TMUXIFY_CONFIG_DIR="$CONFIG_HOME/tmuxify"
+GLOBAL_LAYOUTS_DIR="$TMUXIFY_CONFIG_DIR/layouts"
+GLOBAL_EXAMPLES_DIR="$GLOBAL_LAYOUTS_DIR/examples"
+GLOBAL_DEFAULT_CONFIG_FILE="$GLOBAL_LAYOUTS_DIR/default.yml"
 
 CUSTOM_CONFIG=""
 EXPORT_FLAG=0
@@ -100,13 +106,39 @@ while [ $# -gt 0 ]; do
   shift
 done
 
+install_example_layouts() {
+  local archive temp_extract layouts_dir
+  command -v tar >/dev/null || { warn "tar is required to install example layouts; skipping examples."; return 0; }
+
+  mkdir -p "$GLOBAL_LAYOUTS_DIR" || die "Failed to create config layouts directory: $GLOBAL_LAYOUTS_DIR"
+  archive="$1"
+  temp_extract="$2"
+  mkdir -p "$temp_extract" || die "Failed to prepare example layout directory."
+
+  if ! tar -xzf "$archive" -C "$temp_extract" 2>/dev/null; then
+    warn "Could not extract example layouts from update archive; leaving existing examples unchanged."
+    return 0
+  fi
+  layouts_dir=$(find "$temp_extract" -path '*/examples/layouts' -type d | head -n 1)
+  if [ -z "$layouts_dir" ]; then
+    warn "Could not find example layouts in update archive; leaving existing examples unchanged."
+    return 0
+  fi
+
+  rm -rf "$GLOBAL_EXAMPLES_DIR"
+  mkdir -p "$GLOBAL_EXAMPLES_DIR" || die "Failed to create examples directory: $GLOBAL_EXAMPLES_DIR"
+  cp -R "$layouts_dir/." "$GLOBAL_EXAMPLES_DIR/" || die "Failed to install example layouts."
+  success "Example layouts installed to $GLOBAL_EXAMPLES_DIR"
+}
+
 safe_update() {
-  local temp_dir temp_file first_line candidate_version SCRIPT_PATH INSTALL_DIR INSTALL_PATH backup
+  local temp_dir temp_file examples_archive first_line candidate_version SCRIPT_PATH INSTALL_DIR INSTALL_PATH backup
   command -v curl >/dev/null || die "curl is required for --update."
 
   info "Downloading latest tmuxify..."
   temp_dir=$(mktemp -d 2>/dev/null || mktemp -d -t tmuxify-update) || die "Failed to create temporary directory."
   temp_file="$temp_dir/tmuxify"
+  examples_archive="$temp_dir/tmuxify-examples.tar.gz"
 
   if ! curl -fsSL "$REPO_URL" -o "$temp_file"; then
     rm -rf "$temp_dir"
@@ -126,6 +158,11 @@ safe_update() {
   fi
   chmod +x "$temp_file" || { rm -rf "$temp_dir"; die "Failed to mark downloaded candidate executable."; }
   candidate_version=$(sed -n 's/^VERSION="\([0-9][0-9.]*\)"$/\1/p' "$temp_file" | head -n 1)
+  info "Downloading latest example layouts..."
+  if ! curl -fsSL "$EXAMPLES_ARCHIVE_URL" -o "$examples_archive"; then
+    warn "Failed to download example layouts from $EXAMPLES_ARCHIVE_URL; continuing with script update."
+    examples_archive=""
+  fi
   [ -n "$candidate_version" ] || candidate_version="unknown"
 
   SCRIPT_PATH=$(command -v "$0" 2>/dev/null || printf '%s' "$0")
@@ -144,6 +181,10 @@ safe_update() {
 
   if mv "$temp_file" "$INSTALL_PATH" && chmod +x "$INSTALL_PATH"; then
     [ -e "$backup" ] && rm -f "$backup"
+    mkdir -p "$TMUXIFY_CONFIG_DIR" "$GLOBAL_LAYOUTS_DIR" || { rm -rf "$temp_dir"; die "Failed to create tmuxify config directories."; }
+    if [ -n "$examples_archive" ]; then
+      install_example_layouts "$examples_archive" "$temp_dir/examples"
+    fi
     rm -rf "$temp_dir"
     success "tmuxify updated successfully to version $candidate_version"
     exit 0
@@ -178,6 +219,13 @@ if [ -n "$CUSTOM_CONFIG" ]; then
   fi
   CONFIG_FILE="$CUSTOM_CONFIG"
   info "Using custom layout file: $CONFIG_FILE"
+elif [ -e "$DEFAULT_CONFIG_FILE" ]; then
+  [ -r "$DEFAULT_CONFIG_FILE" ] || die "Cannot read config file: $DEFAULT_CONFIG_FILE"
+  CONFIG_FILE="$DEFAULT_CONFIG_FILE"
+elif [ -e "$GLOBAL_DEFAULT_CONFIG_FILE" ]; then
+  [ -r "$GLOBAL_DEFAULT_CONFIG_FILE" ] || die "Cannot read config file: $GLOBAL_DEFAULT_CONFIG_FILE"
+  CONFIG_FILE="$GLOBAL_DEFAULT_CONFIG_FILE"
+  info "Using global default layout file: $CONFIG_FILE"
 else
   CONFIG_FILE="$DEFAULT_CONFIG_FILE"
 fi


### PR DESCRIPTION
## Summary
- reserve an XDG-compatible tmuxify config directory at `${XDG_CONFIG_HOME:-~/.config}/tmuxify`
- load `layouts/default.yml` from that directory when no project `.tmuxify.yml` exists
- make `tmuxify --update` create the config/layouts folders and refresh bundled examples under `layouts/examples/`
- document the new lookup order and reusable layout setup
- add tests for global default, project override, explicit file override, update-time example install, and pane-base-index-safe focus checks

## Tests
- `bash tests/run.sh`