### PR TITLE
feat: list available layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ cp "${XDG_CONFIG_HOME:-$HOME/.config}/tmuxify/layouts/examples/golang-dev.yml" \
 | `--update` | `-u` | Download and install the latest version safely. |
 | `--help` | `-h` | Display usage instructions. |
 | `--list` | `-l` | List active tmux sessions. |
+| `--list-layouts` | | List project and user layout files. |
 | `--file FILE` | `-f` | Use a specific layout file. |
 | `--export [FILE]` | `-e` | Export current tmux session layout to a simplified YAML template. |
 | `--dry-run` | | Validate and preview the selected layout without creating a tmux session. |
@@ -82,6 +83,7 @@ cp "${XDG_CONFIG_HOME:-$HOME/.config}/tmuxify/layouts/examples/golang-dev.yml" \
 Useful safe workflow:
 
 ```bash
+tmuxify --list-layouts             # list project/default/example layouts
 tmuxify --dry-run                  # inspect the selected layout
 tmuxify --no-commands              # create panes without running commands
 tmuxify                            # normal trusted-project flow

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -48,11 +48,12 @@ run_expect_failure() {
   printf '%s' "$output"
 }
 
-echo "1..13"
+echo "1..14"
 
 output=$(run_expect_success "$TMUXIFY" --help)
 assert_contains "$output" "--dry-run"
 assert_contains "$output" "--no-commands"
+assert_contains "$output" "--list-layouts"
 echo "ok 1 - help documents safe workflow flags"
 
 expected_version=$(<"$ROOT_DIR/VERSION")
@@ -240,7 +241,14 @@ assert_contains "$output" "Example layouts installed"
 [[ -f "$update_xdg_home/tmuxify/layouts/examples/example.yml" ]] || fail "expected update to install example layouts"
 echo "ok 12 - update creates config folders and refreshes example layouts"
 
+output=$(run_expect_success env XDG_CONFIG_HOME="$update_xdg_home" bash -c 'cd "$1" && "$2" --list-layouts' _ "$global_project" "$TMUXIFY")
+assert_contains "$output" "Available tmuxify layouts"
+assert_contains "$output" "project"
+assert_contains "$output" "example"
+assert_contains "$output" "example.yml"
+echo "ok 13 - list-layouts shows project and user layouts"
+
 while IFS= read -r example; do
   run_expect_success "$TMUXIFY" --dry-run --file "$example" >/dev/null
 done < <(find "$ROOT_DIR/examples/layouts" -type f -name '*.yml' -print | sort)
-echo "ok 13 - bundled examples validate"
+echo "ok 14 - bundled examples validate"

--- a/tmuxify
+++ b/tmuxify
@@ -12,6 +12,7 @@ GLOBAL_DEFAULT_CONFIG_FILE="$GLOBAL_LAYOUTS_DIR/default.yml"
 CUSTOM_CONFIG=""
 EXPORT_FLAG=0
 EXPORT_FILENAME=""
+LIST_LAYOUTS=0
 DRY_RUN=0
 DETACH=0
 RUN_COMMANDS=1
@@ -35,6 +36,7 @@ Options:
   -u, --update               Download and install the latest version safely
   -h, --help                 Show help
   -l, --list                 List active tmux sessions
+      --list-layouts         List project and user layout files
   -f, --file LAYOUT_FILE     Use a specific layout file (overrides .tmuxify.yml)
   -e, --export [FILENAME]    Export current tmux session layout to YAML
       --dry-run              Validate and preview the layout without creating tmux sessions
@@ -73,6 +75,9 @@ while [ $# -gt 0 ]; do
       tmux list-sessions || echo "No active tmux sessions found."
       exit 0
       ;;
+    --list-layouts)
+      LIST_LAYOUTS=1
+      ;;
     --file|-f)
       if [ -n "${2:-}" ] && [ "${2#-}" = "$2" ]; then
         CUSTOM_CONFIG="$2"
@@ -105,6 +110,33 @@ while [ $# -gt 0 ]; do
   esac
   shift
 done
+
+list_layouts() {
+  local project_layout found
+  project_layout="$(pwd)/.tmuxify.yml"
+  found=0
+
+  printf 'Available tmuxify layouts:\n'
+  if [ -f "$project_layout" ]; then
+    printf '  project     %s\n' "$project_layout"
+    found=1
+  fi
+  if [ -f "$GLOBAL_DEFAULT_CONFIG_FILE" ]; then
+    printf '  default     %s\n' "$GLOBAL_DEFAULT_CONFIG_FILE"
+    found=1
+  fi
+  if [ -d "$GLOBAL_EXAMPLES_DIR" ]; then
+    while IFS= read -r layout_file; do
+      printf '  example     %s\n' "$layout_file"
+      found=1
+    done < <(find "$GLOBAL_EXAMPLES_DIR" -type f \( -name '*.yml' -o -name '*.yaml' \) -print | sort)
+  fi
+
+  if [ "$found" -eq 0 ]; then
+    printf '  none found\n'
+    printf '\nRun tmuxify --update to download bundled examples into %s\n' "$GLOBAL_EXAMPLES_DIR"
+  fi
+}
 
 install_example_layouts() {
   local archive temp_extract layouts_dir
@@ -197,6 +229,11 @@ safe_update() {
 
 if [ "${UPDATE_REQUESTED:-0}" -eq 1 ]; then
   safe_update
+fi
+
+if [ "$LIST_LAYOUTS" -eq 1 ]; then
+  list_layouts
+  exit 0
 fi
 
 command -v yq >/dev/null || die "yq v4 is required but not found. Please install it (https://github.com/mikefarah/yq)."


### PR DESCRIPTION
## Summary
- add `tmuxify --list-layouts` to list project, global default, and downloaded example layouts
- keep listing independent of tmux/yq so users can inspect layouts before dependencies are installed
- document the new flag and safe workflow usage
- add integration coverage for project and user layout listing

## Tests
- `shellcheck tmuxify`
- `bash tests/run.sh`