### PR TITLE
Fix workspace command controls, sizing, session targeting, and cleanup

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -11,6 +11,8 @@ When you run `tmuxify` without `--file`, layout selection is:
 3. `${XDG_CONFIG_HOME:-$HOME/.config}/tmuxify/layouts/default.yml`.
 4. Built-in four-pane layout.
 
+The built-in workspace uses the same preview and command controls as YAML layouts. Its editor pane starts Neovim when available; otherwise it remains a shell with an installation hint. Neovim is optional. `--dry-run` shows all built-in commands, and `--no-commands` suppresses them, including the editor.
+
 ## Project layout
 
 Put a checked-in `.tmuxify.yml` at a project root when the workspace is useful to everyone on the project:
@@ -68,7 +70,7 @@ If `session.name` is missing, tmuxify derives the session name from the current 
 - leading/trailing `_` are trimmed.
 - an empty result falls back to `tmuxify_session`.
 
-If the session already exists, tmuxify attaches or switches to it instead of rebuilding panes.
+If a session with the exact name already exists, tmuxify attaches or switches to it instead of rebuilding panes. A longer name with the same prefix is a different workspace.
 
 ## Commands and working directory
 

--- a/doc/layout-schema.md
+++ b/doc/layout-schema.md
@@ -84,11 +84,19 @@ layout:
 | Key | Required | Description |
 |---|---:|---|
 | `id` | No | Stable pane identifier for focus. Must start with a letter and contain only letters, numbers, `_`, or `-`. IDs must be unique. |
-| `size` | No | Percent from `1%` to `100%`. Applied best-effort after the split is created. |
+| `size` | No | Percent from `1%` to `100%`, relative to the containing layout's available width or height. |
 | `command` | No | String sent to the pane as shell input after creation. |
 | `type` + `splits` | No | If present, the item is a nested layout container. |
 
 A leaf pane with neither `id` nor `command` is allowed, but tmuxify warns because it creates an unnamed empty shell.
+
+### Size allocation
+
+Sizing applies independently within each parent, including the last child. Separator cells are removed from the parent's available extent before allocation. Omitted sizes share the remaining percentage equally; with no explicit sizes, all siblings share equally. If every size is explicit, their percentages are treated as ratios and normalized to fill the parent, even when their sum differs from 100%.
+
+Each child gets at least one cell. If explicit sizes consume 100% or more, omitted children receive that minimum and explicit ratios share the rest. Other sub-cell allocations are also clamped to one cell and the remaining space is redistributed. Fractional cells are rounded cumulatively in declaration order, so feasible ratios can differ by one cell. Existing percentage values remain valid; oversubscribed ratios are fitted rather than rejected.
+
+If the parent cannot fit even one cell per child plus separators, construction fails and the unfinished session is removed. Enlarge the tmux window or reduce the number of splits.
 
 ## Nested example
 

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -88,7 +88,9 @@ Tmuxify uses native tmux window and pane IDs and does not assume index zero. If 
 
 ## A creation failure occurred
 
-A detected structural failure removes the newly created partial session. If a session remains, verify whether it existed before the run or whether a pane command—not structure creation—failed later. Tmuxify cannot roll back programs after their commands were successfully sent.
+A detected structural failure or HUP/INT/TERM interruption during setup removes the newly created unfinished session and temporary files. Existing and unrelated sessions are preserved. Once setup is complete, attachment or client-switching failure leaves the workspace available to attach later. Temporary files are cleaned before handing control to tmux.
+
+Tmuxify cannot undo external side effects of programs whose commands were already sent, even when an interrupted setup removes their panes.
 
 ## Session attaches instead of rebuilding
 
@@ -119,4 +121,4 @@ tmuxify --export my-new-layout.yml
 
 ## Panes are not the exact requested size
 
-Tmux sizes depend on current terminal size and tmux's layout engine. Use `size` as a starting ratio, then adjust manually if needed.
+Sizes are allocated within each parent layout, not the whole window. Separators, minimum pane dimensions, and integer-cell rounding affect the result. Omitted sizes share the remaining space; oversubscribed percentages are fitted as ratios. See [size allocation](layout-schema.md#size-allocation). If there is not enough room for all panes, enlarge the window or reduce the splits.

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -515,3 +515,9 @@ run_expect_success "$TMUXIFY" --dry-run --file "$single_export_file" >/dev/null
 [[ "$(yq -r '.session.name' "$single_export_file")" == "$single_export_session" ]] || fail "expected YAML-significant session name to round trip"
 [[ "$(yq -r '.windows | length' "$single_export_file")" == "1" && "$(yq -r '.windows[0].layout.splits | length' "$single_export_file")" == "1" ]] || fail "expected one-window one-pane export"
 echo "ok 20 - export preserves all windows, pane structure, active focus, YAML names, and file protections"
+
+# Focused public-boundary regressions can also be run independently.
+for test_file in "$ROOT_DIR"/tests/*-test.sh; do
+  [[ -f "$test_file" ]] || continue
+  bash "$test_file"
+done

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -51,7 +51,13 @@ run_expect_failure() {
   printf '%s' "$output"
 }
 
-echo "1..20"
+test_number=20
+test_count=$test_number
+for test_file in "$ROOT_DIR"/tests/*-test.sh; do
+  [[ -f "$test_file" ]] || continue
+  test_count=$((test_count + 1))
+done
+echo "1..$test_count"
 
 output=$(run_expect_success "$TMUXIFY" --help)
 assert_contains "$output" "--dry-run"
@@ -519,5 +525,11 @@ echo "ok 20 - export preserves all windows, pane structure, active focus, YAML n
 # Focused public-boundary regressions can also be run independently.
 for test_file in "$ROOT_DIR"/tests/*-test.sh; do
   [[ -f "$test_file" ]] || continue
-  bash "$test_file"
+  test_number=$((test_number + 1))
+  if bash "$test_file" 2>&1 | sed 's/^/# /'; then
+    echo "ok $test_number - ${test_file##*/}"
+  else
+    echo "not ok $test_number - ${test_file##*/}"
+    exit 1
+  fi
 done

--- a/tests/workspace-test.sh
+++ b/tests/workspace-test.sh
@@ -38,6 +38,13 @@ for pane in $(tmux list-panes -t '=project' -F '#{pane_id}'); do
 done
 echo 'ok - built-in workspace suppresses commands and retains structure and focus'
 
+mkdir "$TEST_DIR/editor-project"
+(cd "$TEST_DIR/editor-project" && "$TMUXIFY" --detach > "$TEST_DIR/output")
+for _ in {1..100}; do [[ -e "$HOME/editor-started" ]] && break; sleep 0.05; done
+[[ -e "$HOME/editor-started" ]] || fail 'normal default startup did not launch an available editor'
+tmux kill-session -t '=editor-project'
+rm "$HOME/editor-started"
+
 real_tmux=$(command -v tmux)
 cat > "$TEST_DIR/bin/tmux" <<'SH'
 #!/bin/sh
@@ -119,6 +126,7 @@ printf '%s\n' "$geometry" | awk '
   NR == 2 { top_height=$2 }
   NR == 3 { left_width=$1; bottom_height=$2 }
   NR == 4 { if ($1 < 30 || $1 > 33 || left_width-$1 > 1 || $1-left_width > 1 || top_height-bottom_height > 1 || bottom_height-top_height > 1) exit 1 }
+  END { if (NR != 4) exit 1 }
 ' || fail "nested parent-relative 50/50 geometry is wrong: $geometry"
 echo 'ok - nested horizontal and vertical sizes use their parent dimensions'
 
@@ -152,6 +160,10 @@ case "$1" in
 esac
 if [[ "$1" == "${TMUXIFY_INTERRUPT_AT:-}" ]]; then
   "$TMUXIFY_REAL_TMUX" "$@" || exit $?
+  if [[ -n "${TMUXIFY_RENAME_DURING_CREATION:-}" ]]; then
+    "$TMUXIFY_REAL_TMUX" rename-session -t '=interrupted' renamed-owned
+    "$TMUXIFY_REAL_TMUX" new-session -d -s interrupted -n Replacement
+  fi
   kill -s "$TMUXIFY_SIGNAL" "$PPID"
   exit 0
 fi
@@ -195,3 +207,48 @@ tmux has-session -t '=interrupted' || fail 'attachment failure removed a complet
 "$TMUXIFY" --dry-run --file "$TEST_DIR/interrupted.yml" > "$TEST_DIR/output"
 [[ -z $(find "$TMPDIR" -mindepth 1 -print) ]] || fail 'dry-run leaked temporary state'
 echo 'ok - completed workspaces survive attachment failure and dry-run cleans up'
+
+tmux kill-session -t '=interrupted'
+if TMUXIFY_INTERRUPT_AT=new-session TMUXIFY_SIGNAL=TERM TMUXIFY_RENAME_DURING_CREATION=1 "$TMUXIFY" --detach --file "$TEST_DIR/interrupted.yml" > "$TEST_DIR/output" 2>&1; then
+  fail 'interrupted renamed creation unexpectedly succeeded'
+fi
+if tmux has-session -t '=renamed-owned' 2>/dev/null; then fail 'rollback lost track of the renamed owned session'; fi
+[[ $(tmux list-windows -t '=interrupted' -F '#{window_name}') == Replacement ]] || fail 'rollback removed a replacement session with the same name'
+echo 'ok - rollback follows native session identity across a rename'
+
+cat > "$TEST_DIR/vertical.yml" <<'YAML'
+session:
+  name: vertical
+  initial_focus: bottom
+windows:
+  - id: workspace
+    name: Sizes
+    layout:
+      type: vertical
+      splits:
+        - id: editor
+          size: 60%
+        - type: horizontal
+          size: 40%
+          splits:
+            - id: left
+              size: 50%
+            - type: vertical
+              size: 50%
+              splits:
+                - id: top
+                  size: 50%
+                - id: bottom
+                  size: 50%
+YAML
+"$TMUXIFY" --detach --no-commands --file "$TEST_DIR/vertical.yml" > "$TEST_DIR/output"
+heights=$(tmux list-panes -t '=vertical' -F '#{pane_height}' | paste -sd, -)
+[[ $heights == 48,32,15,16 ]] || fail "nested explicit-window vertical geometry is wrong: $heights"
+[[ $(tmux display-message -p -t '=vertical:' '#{pane_index}') -eq 3 ]] || fail 'geometry changes lost explicit-window focus'
+tmux set-option -g default-size 4x4
+sed 's/name: oversubscribed/name: too-small/' "$TEST_DIR/sizing.yml" > "$TEST_DIR/small.yml"
+if "$TMUXIFY" --detach --no-commands --file "$TEST_DIR/small.yml" > "$TEST_DIR/output" 2>&1; then fail 'physically impossible layout unexpectedly succeeded'; fi
+grep -q 'Not enough room' "$TEST_DIR/output" || fail 'impossible layout did not explain the size limit'
+if tmux has-session -t '=too-small' 2>/dev/null; then fail 'impossible layout left an unfinished session'; fi
+[[ -z $(find "$TMPDIR" -mindepth 1 -print) ]] || fail 'impossible layout leaked temporary state'
+echo 'ok - explicit-window vertical geometry preserves focus and impossible layouts fail cleanly'

--- a/tests/workspace-test.sh
+++ b/tests/workspace-test.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+TMUXIFY="$ROOT_DIR/tmuxify"
+TEST_DIR=$(mktemp -d /tmp/tmuxify-workspace.XXXXXX)
+export HOME="$TEST_DIR/home" XDG_CONFIG_HOME="$TEST_DIR/config" TMPDIR="$TEST_DIR/tmp" TMUX_TMPDIR="$TEST_DIR"
+unset TMUX TMUX_PANE
+mkdir -p "$HOME" "$TMPDIR" "$TEST_DIR/bin" "$TEST_DIR/project"
+cleanup() {
+  tmux kill-server >/dev/null 2>&1 || true
+  rm -rf "$TEST_DIR"
+}
+trap cleanup EXIT
+fail() { printf 'not ok - %s\n' "$*" >&2; exit 1; }
+
+tmux -f /dev/null new-session -d -s keepalive -x 161 -y 81
+tmux set-option -g default-shell /bin/bash
+tmux set-option -g default-size 161x81
+cat > "$TEST_DIR/bin/nvim" <<'SH'
+#!/bin/sh
+printf 'editor started\n' > "$HOME/editor-started"
+sleep 60
+SH
+chmod +x "$TEST_DIR/bin/nvim"
+export PATH="$TEST_DIR/bin:$PATH"
+# New pane environments inherit PATH from the server, not this test process.
+tmux set-environment -g PATH "$PATH"
+cd "$TEST_DIR/project"
+
+"$TMUXIFY" --detach --no-commands > "$TEST_DIR/output"
+[[ ! -e "$HOME/editor-started" ]] || fail '--no-commands launched the built-in editor'
+[[ $(tmux list-panes -t '=project' | wc -l) -eq 4 ]] || fail 'expected four default panes'
+[[ $(tmux display-message -p -t '=project:' '#{pane_index}') -eq 0 ]] || fail 'expected editor focus'
+for pane in $(tmux list-panes -t '=project' -F '#{pane_id}'); do
+  text=$(tmux capture-pane -p -t "$pane")
+  [[ $text != *'Top Right Pane'* && $text != *'Bottom Right'* ]] || fail '--no-commands sent built-in commands'
+done
+echo 'ok - built-in workspace suppresses commands and retains structure and focus'
+
+real_tmux=$(command -v tmux)
+cat > "$TEST_DIR/bin/tmux" <<'SH'
+#!/bin/sh
+printf 'tmux contacted\n' > "$HOME/tmux-contacted"
+exit 1
+SH
+chmod +x "$TEST_DIR/bin/tmux"
+"$TMUXIFY" --dry-run --no-commands > "$TEST_DIR/preview"
+[[ ! -e "$HOME/tmux-contacted" && ! -e "$HOME/editor-started" ]] || fail 'preview had side effects'
+grep -q 'command=.*nvim' "$TEST_DIR/preview" || fail 'preview omitted built-in editor command'
+grep -q 'id=terminal' "$TEST_DIR/preview" || fail 'preview omitted built-in panes'
+grep -q 'Commands: disabled' "$TEST_DIR/preview" || fail 'preview omitted command suppression'
+rm "$TEST_DIR/bin/tmux"
+hash -r
+
+tmux kill-session -t '=project'
+mkdir "$TEST_DIR/pane-bin"
+ln -s /usr/bin/clear "$TEST_DIR/pane-bin/clear"
+tmux set-environment -g PATH "$TEST_DIR/pane-bin"
+"$TMUXIFY" --detach > "$TEST_DIR/output"
+editor=$(tmux list-panes -t '=project' -F '#{pane_id}' | head -n 1)
+for _ in {1..100}; do
+  text=$(tmux capture-pane -p -t "$editor")
+  [[ $text == *'Install Neovim or use this shell'* ]] && break
+  sleep 0.05
+done
+[[ $text == *'Install Neovim or use this shell'* ]] || fail 'missing-editor fallback was not usable'
+[[ $(tmux list-panes -t '=project' | wc -l) -eq 4 ]] || fail 'missing editor removed a pane'
+tmux set-environment -g PATH "$PATH"
+echo 'ok - built-in preview is safe and normal startup needs no Neovim'
+
+cat > "$TEST_DIR/session.yml" <<'YAML'
+session:
+  name: api
+layout:
+  type: horizontal
+  splits:
+    - id: shell
+YAML
+tmux new-session -d -s api-worker -n Existing
+"$TMUXIFY" --detach --no-commands --file "$TEST_DIR/session.yml" > "$TEST_DIR/output"
+tmux has-session -t '=api' || fail 'prefix match prevented exact session creation'
+tmux kill-session -t '=api'
+tmux new-session -d -s api-server -n Unrelated
+"$TMUXIFY" --detach --no-commands --file "$TEST_DIR/session.yml" > "$TEST_DIR/output"
+tmux has-session -t '=api' || fail 'multiple prefix matches prevented session creation'
+tmux rename-window -t '=api:' Preserved
+"$TMUXIFY" --detach --file "$TEST_DIR/session.yml" > "$TEST_DIR/output"
+[[ $(tmux list-windows -t '=api' -F '#{window_name}') == Preserved ]] || fail 'exact reuse rebuilt a session'
+[[ $(tmux list-windows -t '=api-worker' -F '#{window_name}') == Existing ]] || fail 'changed prefix session'
+[[ $(tmux list-windows -t '=api-server' -F '#{window_name}') == Unrelated ]] || fail 'changed unrelated session'
+echo 'ok - only exactly matching sessions are reused'
+
+cat > "$TEST_DIR/geometry.yml" <<'YAML'
+session:
+  name: geometry
+layout:
+  type: horizontal
+  splits:
+    - id: editor
+      size: 60%
+    - type: vertical
+      size: 40%
+      splits:
+        - id: top
+          size: 50%
+        - type: horizontal
+          size: 50%
+          splits:
+            - id: left
+              size: 50%
+            - id: right
+              size: 50%
+YAML
+"$TMUXIFY" --detach --no-commands --file "$TEST_DIR/geometry.yml" > "$TEST_DIR/output"
+geometry=$(tmux list-panes -t '=geometry' -F '#{pane_width} #{pane_height} #{pane_left} #{pane_top}')
+printf '%s\n' "$geometry" | awk '
+  NR == 1 { if ($1 < 95 || $1 > 97) exit 1 }
+  NR == 2 { top_height=$2 }
+  NR == 3 { left_width=$1; bottom_height=$2 }
+  NR == 4 { if ($1 < 30 || $1 > 33 || left_width-$1 > 1 || $1-left_width > 1 || top_height-bottom_height > 1 || bottom_height-top_height > 1) exit 1 }
+' || fail "nested parent-relative 50/50 geometry is wrong: $geometry"
+echo 'ok - nested horizontal and vertical sizes use their parent dimensions'
+
+for scenario in final mixed automatic oversubscribed; do
+  case "$scenario" in
+    final) sizes=$'    - id: first\n    - id: last\n      size: 75%' ;;
+    mixed) sizes=$'    - id: first\n      size: 25%\n    - id: middle\n    - id: last\n      size: 25%' ;;
+    automatic) sizes=$'    - id: first\n    - id: middle\n    - id: last' ;;
+    oversubscribed) sizes=$'    - id: first\n      size: 100%\n    - id: middle\n      size: 100%\n    - id: last' ;;
+  esac
+  printf 'session:\n  name: %s\nlayout:\n  type: horizontal\n  splits:\n%s\n' "$scenario" "$sizes" > "$TEST_DIR/sizing.yml"
+  "$TMUXIFY" --detach --no-commands --file "$TEST_DIR/sizing.yml" > "$TEST_DIR/output"
+  widths=$(tmux list-panes -t "=$scenario" -F '#{pane_width}' | paste -sd, -)
+  case "$scenario:$widths" in
+    final:40,120|mixed:39,80,40|automatic:53,53,53|oversubscribed:79,79,1) ;;
+    *) fail "unexpected $scenario allocation: $widths" ;;
+  esac
+done
+echo 'ok - final sizes, omitted sizes, and infeasible ratios have deterministic allocations'
+
+# Attachment is an external boundary: inspect the handoff without needing a TTY.
+export TMUXIFY_REAL_TMUX="$real_tmux"
+cat > "$TEST_DIR/bin/tmux" <<'SH'
+#!/usr/bin/env bash
+case "$1" in
+  attach|switch-client)
+    printf '%s\n' "$@" > "$HOME/handoff"
+    find "$TMPDIR" -type f > "$HOME/handoff-files"
+    exit "${TMUXIFY_ATTACH_STATUS:-0}"
+    ;;
+esac
+if [[ "$1" == "${TMUXIFY_INTERRUPT_AT:-}" ]]; then
+  "$TMUXIFY_REAL_TMUX" "$@" || exit $?
+  kill -s "$TMUXIFY_SIGNAL" "$PPID"
+  exit 0
+fi
+if [[ "$1" == "${TMUXIFY_FAIL_AT:-}" ]]; then exit 1; fi
+exec "$TMUXIFY_REAL_TMUX" "$@"
+SH
+chmod +x "$TEST_DIR/bin/tmux"
+"$TMUXIFY" --file "$TEST_DIR/session.yml" > "$TEST_DIR/output"
+[[ ! -s "$HOME/handoff-files" ]] || fail 'attachment leaked temporary files'
+grep -qx '=api' "$HOME/handoff" || fail 'attachment did not use an exact session target'
+TMUX=simulated "$TMUXIFY" --file "$TEST_DIR/session.yml" > "$TEST_DIR/output"
+[[ ! -s "$HOME/handoff-files" ]] || fail 'client switching leaked temporary files'
+grep -qx 'switch-client' "$HOME/handoff" || fail 'expected client switch'
+grep -qx '=api' "$HOME/handoff" || fail 'client switching did not use an exact target'
+echo 'ok - attachment and switching clean temporary files before exact-target handoff'
+
+sed 's/name: api/name: interrupted/' "$TEST_DIR/session.yml" > "$TEST_DIR/interrupted.yml"
+for point in new-session set-window-option; do
+  for signal in HUP INT TERM; do
+    if TMUXIFY_INTERRUPT_AT="$point" TMUXIFY_SIGNAL="$signal" "$TMUXIFY" --detach --no-commands --file "$TEST_DIR/interrupted.yml" > "$TEST_DIR/output" 2>&1; then
+      fail "$signal at $point unexpectedly succeeded"
+    fi
+    if tmux has-session -t '=interrupted' 2>/dev/null; then fail "$signal at $point left an unfinished session"; fi
+    [[ -z $(find "$TMPDIR" -mindepth 1 -print) ]] || fail "$signal at $point leaked temporary state"
+    tmux has-session -t '=api-worker' || fail 'interruption removed an unrelated session'
+    tmux has-session -t '=api' || fail 'interruption removed an existing session'
+  done
+done
+if TMUXIFY_FAIL_AT=set-window-option "$TMUXIFY" --detach --file "$TEST_DIR/interrupted.yml" > "$TEST_DIR/output" 2>&1; then
+  fail 'construction failure unexpectedly succeeded'
+fi
+if tmux has-session -t '=interrupted' 2>/dev/null; then fail 'construction failure left an unfinished session'; fi
+[[ -z $(find "$TMPDIR" -mindepth 1 -print) ]] || fail 'construction failure leaked temporary state'
+echo 'ok - signals and structural failures roll back only unfinished owned sessions'
+
+if TMUXIFY_ATTACH_STATUS=7 "$TMUXIFY" --no-commands --file "$TEST_DIR/interrupted.yml" > "$TEST_DIR/output" 2>&1; then
+  fail 'attachment failure unexpectedly succeeded'
+fi
+tmux has-session -t '=interrupted' || fail 'attachment failure removed a completed workspace'
+[[ ! -s "$HOME/handoff-files" ]] || fail 'new-session attachment leaked temporary state'
+"$TMUXIFY" --dry-run --file "$TEST_DIR/interrupted.yml" > "$TEST_DIR/output"
+[[ -z $(find "$TMPDIR" -mindepth 1 -print) ]] || fail 'dry-run leaked temporary state'
+echo 'ok - completed workspaces survive attachment failure and dry-run cleans up'

--- a/tests/workspace-test.sh
+++ b/tests/workspace-test.sh
@@ -16,6 +16,8 @@ fail() { printf 'not ok - %s\n' "$*" >&2; exit 1; }
 
 tmux -f /dev/null new-session -d -s keepalive -x 161 -y 81
 tmux set-option -g default-shell /bin/bash
+# Keep host login profiles out of the controlled pane environment.
+tmux set-option -g default-command 'exec /bin/bash --noprofile --norc'
 tmux set-option -g default-size 161x81
 cat > "$TEST_DIR/bin/nvim" <<'SH'
 #!/bin/sh
@@ -24,8 +26,6 @@ sleep 60
 SH
 chmod +x "$TEST_DIR/bin/nvim"
 export PATH="$TEST_DIR/bin:$PATH"
-# New pane environments inherit PATH from the server, not this test process.
-tmux set-environment -g PATH "$PATH"
 cd "$TEST_DIR/project"
 
 "$TMUXIFY" --detach --no-commands > "$TEST_DIR/output"
@@ -63,17 +63,21 @@ hash -r
 tmux kill-session -t '=project'
 mkdir "$TEST_DIR/pane-bin"
 ln -s /usr/bin/clear "$TEST_DIR/pane-bin/clear"
-tmux set-environment -g PATH "$TEST_DIR/pane-bin"
+# tmux can inject the creating client's PATH even when its global PATH differs.
+# Set the absent-tool PATH inside the pane shell, without changing CLI dependencies.
+tmux set-option -g default-command "export PATH='$TEST_DIR/pane-bin'; exec /bin/bash --noprofile --norc"
 "$TMUXIFY" --detach > "$TEST_DIR/output"
 editor=$(tmux list-panes -t '=project' -F '#{pane_id}' | head -n 1)
+fallback_message='Install Neovim or use this shell for your editor.'
 for _ in {1..100}; do
   text=$(tmux capture-pane -p -t "$editor")
-  [[ $text == *'Install Neovim or use this shell'* ]] && break
+  grep -Fxq "$fallback_message" <<< "$text" && break
   sleep 0.05
 done
-[[ $text == *'Install Neovim or use this shell'* ]] || fail 'missing-editor fallback was not usable'
+grep -Fxq "$fallback_message" <<< "$text" || fail "missing-editor fallback was not usable; pane contents: $text"
+[[ ! -e "$HOME/editor-started" ]] || fail 'missing-editor fixture launched the editor stub'
 [[ $(tmux list-panes -t '=project' | wc -l) -eq 4 ]] || fail 'missing editor removed a pane'
-tmux set-environment -g PATH "$PATH"
+tmux set-option -g default-command 'exec /bin/bash --noprofile --norc'
 echo 'ok - built-in preview is safe and normal startup needs no Neovim'
 
 cat > "$TEST_DIR/session.yml" <<'YAML'

--- a/tmuxify
+++ b/tmuxify
@@ -22,15 +22,13 @@ RUN_COMMANDS=1
 TMP_DIR=""
 EXPORT_TEMP_FILE=""
 SESSION_CREATED=0
+SESSION_CREATING=0
+INTERRUPTED_STATUS=0
 
 info() { printf '%s\n' "ℹ️ $*"; }
 success() { printf '%s\n' "✅ $*"; }
 warn() { printf '%s\n' "⚠️ $*"; }
 die() {
-  if [ "${SESSION_CREATED:-0}" -eq 1 ] && [ -n "${session_name:-}" ]; then
-    tmux kill-session -t "=$session_name" 2>/dev/null || true
-    SESSION_CREATED=0
-  fi
   printf '%s\n' "❌ Error: $*" >&2
   exit 1
 }
@@ -63,6 +61,10 @@ EOF
 }
 
 cleanup() {
+  if [ "$SESSION_CREATED" -eq 1 ]; then
+    tmux kill-session -t "=$session_name" 2>/dev/null || true
+    SESSION_CREATED=0
+  fi
   if [ -n "$EXPORT_TEMP_FILE" ]; then
     rm -f "$EXPORT_TEMP_FILE"
   fi
@@ -70,7 +72,19 @@ cleanup() {
     rm -rf "$TMP_DIR"
   fi
 }
-trap cleanup EXIT HUP INT TERM
+handle_signal() {
+  # A signal may arrive after tmux created the session but before ownership was
+  # recorded. Finish that one transition before exiting and rolling back.
+  if [ "$SESSION_CREATING" -eq 1 ]; then
+    INTERRUPTED_STATUS="$1"
+  else
+    exit "$1"
+  fi
+}
+trap cleanup EXIT
+trap 'handle_signal 129' HUP
+trap 'handle_signal 130' INT
+trap 'handle_signal 143' TERM
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -623,6 +637,38 @@ if [ "$EXPORT_FLAG" -eq 1 ]; then
   export_session
 fi
 
+# Use the same preview, construction, and command controls for the built-in layout.
+if [ ! -f "$CONFIG_FILE" ]; then
+  init_tmp_dir
+  CONFIG_FILE="$TMP_DIR/default.yml"
+  cat > "$CONFIG_FILE" <<'YAML'
+session:
+  initial_focus: editor
+layout:
+  type: horizontal
+  splits:
+    - id: editor
+      size: 50%
+      command: "if command -v nvim >/dev/null 2>&1; then nvim .; else printf '%s\\n' 'Install Neovim or use this shell for your editor.'; fi"
+    - type: vertical
+      size: 50%
+      splits:
+        - id: assistant
+          size: 50%
+          command: "echo 'Top Right Pane (e.g., aider)'"
+        - type: horizontal
+          size: 50%
+          splits:
+            - id: git
+              size: 50%
+              command: "echo 'Bottom Left (e.g., lazygit)'"
+            - id: terminal
+              size: 50%
+              command: "clear && echo 'Bottom Right (terminal)'"
+YAML
+  info "Using default 4-pane workspace."
+fi
+
 validate_config
 
 # Generate session name from directory path
@@ -688,17 +734,20 @@ fi
 attach_or_switch() {
   local target_session
   target_session="$1"
+  # Construction is committed; attachment failure must not destroy the workspace.
+  SESSION_CREATED=0
+  cleanup
   if [ "$DETACH" -eq 1 ]; then
     success "Session '$target_session' is ready. Attach with: tmux attach -t $target_session"
     exit 0
   fi
   if [ -n "$TMUX" ]; then
-    exec tmux switch-client -t "$target_session"
+    exec tmux switch-client -t "=$target_session"
   fi
-  exec tmux attach -t "$target_session"
+  exec tmux attach -t "=$target_session"
 }
 
-if tmux has-session -t "$session_name" 2>/dev/null; then
+if tmux has-session -t "=$session_name" 2>/dev/null; then
   success "Attaching to existing session: $session_name"
   attach_or_switch "$session_name"
 fi
@@ -709,18 +758,40 @@ tmux_or_die() {
   fi
 }
 
-apply_size() {
-  local layout_type pane_target size_value size_percent
-  layout_type="$1"
-  pane_target="$2"
-  size_value="$3"
-  if [ -z "$size_value" ] || [ "$size_value" = "null" ]; then return 0; fi
-  size_percent=$(printf '%s' "$size_value" | sed 's/%$//')
-  if [ "$layout_type" = "horizontal" ]; then
-    tmux resize-pane -t "$pane_target" -x "$size_percent%" >/dev/null 2>&1 || warn "Could not resize pane $pane_target to width $size_value."
-  else
-    tmux resize-pane -t "$pane_target" -y "$size_percent%" >/dev/null 2>&1 || warn "Could not resize pane $pane_target to height $size_value."
-  fi
+# Allocate the parent extent once, reserving separators and at least one cell
+# per child. Normalize oversubscribed (or fully explicit) ratios to fit.
+allocate_pane_sizes() {
+  yq -r "$1.splits[].size // \"auto\"" "$CONFIG_FILE" | awk -v extent="$2" '
+    { n++; if ($0 == "auto") { automatic[n]=1; autos++ }
+      else { weights[n]=$0+0; explicit+=$0 } }
+    END {
+      remaining=extent-(n-1)
+      if (remaining < n) exit 1
+      share=(autos && explicit < 100) ? (100-explicit)/autos : 0
+      for (i=1; i<=n; i++) {
+        if (automatic[i]) weights[i]=share
+        total+=weights[i]
+      }
+      # Clamp undersized children, then redistribute among the others.
+      do {
+        changed=0
+        for (i=1; i<=n; i++) {
+          if (!fixed[i] && (!weights[i] || remaining*weights[i]/total < 1)) {
+            cells[i]=1; fixed[i]=1; remaining--; total-=weights[i]; changed=1
+          }
+        }
+      } while (changed)
+      cumulative=0; allocated=0
+      for (i=1; i<=n; i++) {
+        if (!fixed[i]) {
+          cumulative+=weights[i]
+          next_total=int(remaining*cumulative/total+0.000001)
+          cells[i]=next_total-allocated; allocated=next_total
+        }
+        printf "%s%d", (i == 1 ? "" : " "), cells[i]
+      }
+      printf "\n"
+    }'
 }
 
 queue_configured_command() {
@@ -740,11 +811,22 @@ dispatch_configured_commands() {
 }
 
 build_layout() {
-  local layout_path container_pane layout_type count i prev_pane item_path current_pane split_flag previous_item_path previous_size has_nested has_command pane_id
+  local layout_path container_pane layout_type count i prev_pane item_path current_pane split_flag has_nested has_command pane_id extent size_plan remaining
+  local -a pane_sizes
   layout_path="$1"
   container_pane="$2"
   layout_type=$(yq -r "$layout_path.type" "$CONFIG_FILE")
   count=$(yq -r "$layout_path.splits | length" "$CONFIG_FILE")
+  if [ "$layout_type" = "horizontal" ]; then
+    split_flag="-h"
+    extent=$(tmux display-message -p -t "$container_pane" '#{pane_width}') || die "Failed to read parent width."
+  else
+    split_flag="-v"
+    extent=$(tmux display-message -p -t "$container_pane" '#{pane_height}') || die "Failed to read parent height."
+  fi
+  size_plan=$(allocate_pane_sizes "$layout_path" "$extent") || die "Not enough room for $count panes at $layout_path. Enlarge the tmux window or reduce the splits."
+  read -r -a pane_sizes <<< "$size_plan"
+  remaining="$extent"
 
   i=0
   prev_pane=""
@@ -753,16 +835,9 @@ build_layout() {
     if [ "$i" -eq 0 ]; then
       current_pane="$container_pane"
     else
-      if [ "$layout_type" = "horizontal" ]; then
-        split_flag="-h"
-      else
-        split_flag="-v"
-      fi
-      current_pane=$(tmux split-window "$split_flag" -t "$prev_pane" -c "$WORKDIR" -P -F '#{pane_id}') ||
+      remaining=$((remaining - pane_sizes[i - 1] - 1))
+      current_pane=$(tmux split-window "$split_flag" -l "$remaining" -t "$prev_pane" -c "$WORKDIR" -P -F '#{pane_id}') ||
         die "Failed to split pane $prev_pane while building $layout_path."
-      previous_item_path="$layout_path.splits[$((i - 1))]"
-      previous_size=$(yq -r "$previous_item_path.size // \"\"" "$CONFIG_FILE")
-      apply_size "$layout_type" "$prev_pane" "$previous_size"
     fi
     record_build_pane "$layout_path" "$i" "$current_pane"
     prev_pane="$current_pane"
@@ -790,42 +865,24 @@ build_layout() {
   done
 }
 
-create_default_layout() {
-  local pane0 pane1 pane2 pane3
-  info "Using default 4-pane layout."
-  tmux_or_die tmux new-session -d -s "$session_name" -c "$WORKDIR" "nvim ."
-  SESSION_CREATED=1
-  tmux_or_die tmux set-window-option -t "$session_name" aggressive-resize on
-  pane0=$(tmux display-message -t "$session_name" -p '#{pane_id}') || die "Failed to identify initial pane."
-  pane1=$(tmux split-window -h -t "$pane0" -c "$WORKDIR" -P -F '#{pane_id}') || die "Failed to create default pane."
-  apply_size horizontal "$pane0" "50%"
-  pane2=$(tmux split-window -v -t "$pane1" -c "$WORKDIR" -P -F '#{pane_id}') || die "Failed to create default pane."
-  apply_size vertical "$pane1" "50%"
-  pane3=$(tmux split-window -h -t "$pane2" -c "$WORKDIR" -P -F '#{pane_id}') || die "Failed to create default pane."
-  apply_size horizontal "$pane2" "50%"
-  tmux_or_die tmux send-keys -t "$pane1" "echo 'Top Right Pane (e.g., aider)'" C-m
-  tmux_or_die tmux send-keys -t "$pane2" "echo 'Bottom Left (e.g., lazygit)'" C-m
-  tmux_or_die tmux send-keys -t "$pane3" "clear && echo 'Bottom Right (terminal)'" C-m
-  tmux_or_die tmux select-pane -t "$pane0"
-}
-
 echo "🚀 Creating new session: $session_name"
-
-if [ ! -f "$CONFIG_FILE" ]; then
-  create_default_layout
-  success "Session '$session_name' created successfully."
-  attach_or_switch "$session_name"
-fi
 
 # reset runtime maps after validation
 : > "$TMP_DIR/pane_id_map"
 : > "$TMP_DIR/build_panes"
 
-tmux_or_die tmux new-session -d -s "$session_name" -c "$WORKDIR"
-SESSION_CREATED=1
+SESSION_CREATING=1
+if tmux new-session -d -s "$session_name" -c "$WORKDIR"; then
+  SESSION_CREATED=1
+else
+  SESSION_CREATING=0
+  die "Failed to create session '$session_name'."
+fi
+SESSION_CREATING=0
+[ "$INTERRUPTED_STATUS" -eq 0 ] || exit "$INTERRUPTED_STATUS"
 info "Building layout from $CONFIG_FILE..."
-tmux_or_die tmux set-window-option -t "$session_name" aggressive-resize on
-root_pane=$(tmux display-message -t "$session_name" -p '#{pane_id}') || die "Failed to identify initial pane."
+tmux_or_die tmux set-window-option -t "=$session_name:" aggressive-resize on
+root_pane=$(tmux display-message -t "=$session_name:" -p '#{pane_id}') || die "Failed to identify initial pane."
 first_pane="$root_pane"
 if [ "$(yq -r 'has("windows")' "$CONFIG_FILE")" = "true" ]; then
   window_count=$(yq -r '.windows | length' "$CONFIG_FILE")
@@ -838,7 +895,7 @@ if [ "$(yq -r 'has("windows")' "$CONFIG_FILE")" = "true" ]; then
       native_window=$(tmux display-message -t "$window_pane" -p '#{window_id}') || die "Failed to identify initial window."
       tmux_or_die tmux rename-window -t "$native_window" "$window_name"
     else
-      window_result=$(tmux new-window -d -t "$session_name" -c "$WORKDIR" -n "$window_name" -P -F '#{window_id} #{pane_id}') ||
+      window_result=$(tmux new-window -d -t "=$session_name:" -c "$WORKDIR" -n "$window_name" -P -F '#{window_id} #{pane_id}') ||
         die "Failed to create configured window '$window_id'."
       native_window=${window_result%% *}
       window_pane=${window_result#* }

--- a/tmuxify
+++ b/tmuxify
@@ -22,6 +22,7 @@ RUN_COMMANDS=1
 TMP_DIR=""
 EXPORT_TEMP_FILE=""
 SESSION_CREATED=0
+CREATED_SESSION_ID=""
 SESSION_CREATING=0
 INTERRUPTED_STATUS=0
 
@@ -62,7 +63,7 @@ EOF
 
 cleanup() {
   if [ "$SESSION_CREATED" -eq 1 ]; then
-    tmux kill-session -t "=$session_name" 2>/dev/null || true
+    tmux kill-session -t "$CREATED_SESSION_ID" 2>/dev/null || true
     SESSION_CREATED=0
   fi
   if [ -n "$EXPORT_TEMP_FILE" ]; then
@@ -681,44 +682,35 @@ if [ "$original_auto_name" != "$auto_session_name" ]; then
   warn "Directory name '$original_auto_name' sanitized to '$auto_session_name' for tmux compatibility"
 fi
 
-if [ -f "$CONFIG_FILE" ]; then
-  session_name=$(yq -r '.session.name // ""' "$CONFIG_FILE")
-  if [ -z "$session_name" ] || [ "$session_name" = "null" ]; then
-    session_name="$auto_session_name"
-    info "Using auto-generated session name: $session_name"
-  else
-    original_name="$session_name"
-    session_name=$(sanitize_name "$session_name")
-    [ -n "$session_name" ] || die "Configured session name becomes empty after sanitization."
-    if [ "$original_name" != "$session_name" ]; then
-      warn "Session name '$original_name' from config sanitized to '$session_name' for tmux compatibility"
-    else
-      info "Using session name from config: $session_name"
-    fi
-  fi
-else
+session_name=$(yq -r '.session.name // ""' "$CONFIG_FILE")
+if [ -z "$session_name" ] || [ "$session_name" = "null" ]; then
   session_name="$auto_session_name"
-  info "No layout file found. Using auto-generated session name: $session_name"
+  info "Using auto-generated session name: $session_name"
+else
+  original_name="$session_name"
+  session_name=$(sanitize_name "$session_name")
+  [ -n "$session_name" ] || die "Configured session name becomes empty after sanitization."
+  if [ "$original_name" != "$session_name" ]; then
+    warn "Session name '$original_name' from config sanitized to '$session_name' for tmux compatibility"
+  else
+    info "Using session name from config: $session_name"
+  fi
 fi
 
 if [ "$DRY_RUN" -eq 1 ]; then
   success "Configuration is valid."
   printf 'Session: %s\n' "$session_name"
-  if [ -f "$CONFIG_FILE" ]; then
-    printf 'Layout plan:\n'
-    if [ "$(yq -r 'has("windows")' "$CONFIG_FILE")" = "true" ]; then
-      window_count=$(yq -r '.windows | length' "$CONFIG_FILE")
-      i=0
-      while [ "$i" -lt "$window_count" ]; do
-        printf '  Window: %s (%s)\n' "$(yq -r ".windows[$i].id" "$CONFIG_FILE")" "$(yq -r ".windows[$i].name" "$CONFIG_FILE")"
-        print_plan_node ".windows[$i].layout" "    "
-        i=$((i + 1))
-      done
-    else
-      print_plan_node ".layout" "  "
-    fi
+  printf 'Layout plan:\n'
+  if [ "$(yq -r 'has("windows")' "$CONFIG_FILE")" = "true" ]; then
+    window_count=$(yq -r '.windows | length' "$CONFIG_FILE")
+    i=0
+    while [ "$i" -lt "$window_count" ]; do
+      printf '  Window: %s (%s)\n' "$(yq -r ".windows[$i].id" "$CONFIG_FILE")" "$(yq -r ".windows[$i].name" "$CONFIG_FILE")"
+      print_plan_node ".windows[$i].layout" "    "
+      i=$((i + 1))
+    done
   else
-    printf 'Layout plan:\n  - default 4-pane workspace\n'
+    print_plan_node ".layout" "  "
   fi
   [ "$RUN_COMMANDS" -eq 1 ] && printf 'Commands: would run configured pane commands.\n' || printf 'Commands: disabled by --no-commands.\n'
   exit 0
@@ -872,7 +864,7 @@ echo "🚀 Creating new session: $session_name"
 : > "$TMP_DIR/build_panes"
 
 SESSION_CREATING=1
-if tmux new-session -d -s "$session_name" -c "$WORKDIR"; then
+if CREATED_SESSION_ID=$(tmux new-session -d -s "$session_name" -c "$WORKDIR" -P -F '#{session_id}'); then
   SESSION_CREATED=1
 else
   SESSION_CREATING=0
@@ -881,8 +873,8 @@ fi
 SESSION_CREATING=0
 [ "$INTERRUPTED_STATUS" -eq 0 ] || exit "$INTERRUPTED_STATUS"
 info "Building layout from $CONFIG_FILE..."
-tmux_or_die tmux set-window-option -t "=$session_name:" aggressive-resize on
-root_pane=$(tmux display-message -t "=$session_name:" -p '#{pane_id}') || die "Failed to identify initial pane."
+tmux_or_die tmux set-window-option -t "$CREATED_SESSION_ID:" aggressive-resize on
+root_pane=$(tmux display-message -t "$CREATED_SESSION_ID:" -p '#{pane_id}') || die "Failed to identify initial pane."
 first_pane="$root_pane"
 if [ "$(yq -r 'has("windows")' "$CONFIG_FILE")" = "true" ]; then
   window_count=$(yq -r '.windows | length' "$CONFIG_FILE")
@@ -895,7 +887,7 @@ if [ "$(yq -r 'has("windows")' "$CONFIG_FILE")" = "true" ]; then
       native_window=$(tmux display-message -t "$window_pane" -p '#{window_id}') || die "Failed to identify initial window."
       tmux_or_die tmux rename-window -t "$native_window" "$window_name"
     else
-      window_result=$(tmux new-window -d -t "=$session_name:" -c "$WORKDIR" -n "$window_name" -P -F '#{window_id} #{pane_id}') ||
+      window_result=$(tmux new-window -d -t "$CREATED_SESSION_ID:" -c "$WORKDIR" -n "$window_name" -P -F '#{window_id} #{pane_id}') ||
         die "Failed to create configured window '$window_id'."
       native_window=${window_result%% *}
       window_pane=${window_result#* }


### PR DESCRIPTION
## Summary

- Build the no-config workspace through the same YAML preview/construction/command pipeline; honor `--no-commands` and keep a usable shell when Neovim is absent.
- Allocate sibling sizes within their parent, including final-child percentages, omitted sizes, separator cells, and minimum dimensions. Document ratio fitting and fail cleanly when panes cannot physically fit.
- Reuse and attach only to exactly matching sessions; use native session identity during construction and rollback.
- Clean temporary state before attachment and terminate/roll back unfinished owned sessions on HUP, INT, and TERM, including signals at the session-creation boundary.

Closes #12
Closes #13
Closes #14
Closes #15

## Verification

- Reproduced the original failures with public-CLI regression tests before fixing them.
- `bash tests/workspace-test.sh` passes on Bash 5.3 and an actual locally built Bash 3.2 interpreter (including invoking tmuxify through Bash 3.2).
- Full `bash tests/run.sh` passes in an isolated tmux environment: the original 20 checks, all bundled layout previews, and the new focused regressions.
- ShellCheck 0.11.0 and individual Bash 3.2/current-Bash syntax checks pass.
- Verified geometry in a controlled-size tmux window, exact reuse/prefix collisions, attachment handoff, native-ID rollback across a rename, and preservation of completed/unrelated sessions.

## Review

Reviewed against `15db7bc` on two axes (separate self-review passes; no subagent tool available):

- **Standards:** no remaining findings against the documented Bash portability, explicit command execution, and clear-error rules. Removed unreachable fallback branches instead of introducing a new module/framework.
- **Spec:** no remaining findings against #12–#15. Review caught and fixed rollback-by-name incorrectly handling a renamed session; its regression now verifies that a replacement session with the original name is preserved.

## Integration / scope

Independently based on `main`. All three reliability PR branches were also merged into a temporary integration worktree without conflicts, and the combined full suite passed. No new flags, configuration schema, workspace registry, or reconciliation behavior.
