### PR TITLE
Validate update candidates and preserve recoverable installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ System-wide installs are fine when managed by an admin or package manager, but a
 tmuxify --update
 ```
 
-The updater downloads to a temporary file, checks that the candidate is executable and can report a version, backs up the current script, and replaces it only if the install path is writable.
+The updater checks the downloaded candidate's Bash shebang, syntax, and embedded numeric version without executing it. It stages an executable replacement beside the writable install path and backs up the current script before an atomic rename. Failed replacement restores the backup; if restoration also fails, the error gives the retained backup path. These checks detect malformed downloads, not malicious code or release authenticity.
 
 ## Usage
 

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -36,7 +36,11 @@ Avoid piping mutable scripts into `sudo`. If you need a system-wide install, use
 tmuxify --update
 ```
 
-The updater downloads to a temporary file, checks that the candidate is executable and can report a version, backs up the current script, and replaces it only when the install path is writable. It does not automatically escalate with `sudo`.
+The updater checks the candidate's Bash shebang, Bash syntax, and one embedded numeric `major.minor.patch` version. It does not execute the downloaded program for validation. Invalid candidates leave the installation unchanged.
+
+The replacement is staged beside the writable install path and made executable before an atomic rename. A backup preserves the previous version on replacement failure. If automatic restoration also fails, the error reports a retained recovery backup to restore manually. Examples and completions are still refreshed on successful script updates. The updater does not automatically escalate with `sudo`.
+
+These are format and syntax checks, not authenticity checks or a sandbox. For higher assurance, install a reviewed release or pinned commit rather than a mutable branch.
 
 ## User config directory
 

--- a/doc/security.md
+++ b/doc/security.md
@@ -40,7 +40,9 @@ command: clear && echo "Manual: run deploy only after checking target"
 
 ## Updating safely
 
-`tmuxify --update` downloads a candidate script, checks that it is executable and can report a version, backs up the current script, and replaces it only when the install path is writable. It does not automatically escalate with `sudo`.
+`tmuxify --update` checks a candidate's Bash shebang, syntax, and embedded numeric version without executing it. It prepares executable permissions before replacing the writable installation and keeps a backup for recovery. If replacement and restoration both fail, the error identifies the retained backup. It does not automatically escalate with `sudo`.
+
+These checks reject malformed downloads; they do not authenticate a release or establish that its code is safe.
 
 For higher-assurance environments, install reviewed releases or pinned commits rather than updating from a mutable branch.
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -515,3 +515,9 @@ run_expect_success "$TMUXIFY" --dry-run --file "$single_export_file" >/dev/null
 [[ "$(yq -r '.session.name' "$single_export_file")" == "$single_export_session" ]] || fail "expected YAML-significant session name to round trip"
 [[ "$(yq -r '.windows | length' "$single_export_file")" == "1" && "$(yq -r '.windows[0].layout.splits | length' "$single_export_file")" == "1" ]] || fail "expected one-window one-pane export"
 echo "ok 20 - export preserves all windows, pane structure, active focus, YAML names, and file protections"
+
+# Focused public-boundary regressions can also be run independently.
+for test_file in "$ROOT_DIR"/tests/*-test.sh; do
+  [[ -f "$test_file" ]] || continue
+  bash "$test_file"
+done

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -51,7 +51,13 @@ run_expect_failure() {
   printf '%s' "$output"
 }
 
-echo "1..20"
+test_number=20
+test_count=$test_number
+for test_file in "$ROOT_DIR"/tests/*-test.sh; do
+  [[ -f "$test_file" ]] || continue
+  test_count=$((test_count + 1))
+done
+echo "1..$test_count"
 
 output=$(run_expect_success "$TMUXIFY" --help)
 assert_contains "$output" "--dry-run"
@@ -519,5 +525,11 @@ echo "ok 20 - export preserves all windows, pane structure, active focus, YAML n
 # Focused public-boundary regressions can also be run independently.
 for test_file in "$ROOT_DIR"/tests/*-test.sh; do
   [[ -f "$test_file" ]] || continue
-  bash "$test_file"
+  test_number=$((test_number + 1))
+  if bash "$test_file" 2>&1 | sed 's/^/# /'; then
+    echo "ok $test_number - ${test_file##*/}"
+  else
+    echo "not ok $test_number - ${test_file##*/}"
+    exit 1
+  fi
 done

--- a/tests/update-test.sh
+++ b/tests/update-test.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+TEST_DIR=$(mktemp -d /tmp/tmuxify-update-test.XXXXXX)
+trap 'rm -rf "$TEST_DIR"' EXIT
+export HOME="$TEST_DIR/home" XDG_CONFIG_HOME="$TEST_DIR/config" TMPDIR="$TEST_DIR/tmp"
+mkdir -p "$HOME" "$TMPDIR" "$TEST_DIR/install" "$TEST_DIR/archive/tmuxify/examples/layouts" "$TEST_DIR/archive/tmuxify/completions"
+fail() { printf 'not ok - %s\n' "$*" >&2; exit 1; }
+
+printf 'layout: {type: horizontal, splits: [{id: shell}]}\n' > "$TEST_DIR/archive/tmuxify/examples/layouts/example.yml"
+cp "$ROOT_DIR"/completions/* "$TEST_DIR/archive/tmuxify/completions/"
+(cd "$TEST_DIR/archive" && tar -czf "$TEST_DIR/assets.tar.gz" tmuxify)
+export TMUXIFY_EXAMPLES_ARCHIVE_URL="file://$TEST_DIR/assets.tar.gz"
+export TMUXIFY_COMPLETIONS_ARCHIVE_URL="$TMUXIFY_EXAMPLES_ARCHIVE_URL"
+export TMUXIFY_REPO_URL="file://$TEST_DIR/candidate"
+
+cp "$ROOT_DIR/tmuxify" "$TEST_DIR/install/tmuxify"
+printf '#!/usr/bin/env bash\nVERSION="9.9.9"\nif (\n' > "$TEST_DIR/candidate"
+if "$TEST_DIR/install/tmuxify" --update > "$TEST_DIR/output" 2>&1; then
+  fail 'syntactically invalid candidate replaced a working installation'
+fi
+cmp -s "$ROOT_DIR/tmuxify" "$TEST_DIR/install/tmuxify" || fail 'rejected candidate changed the installation'
+echo 'ok - update rejects invalid Bash before replacing the installation'
+
+for invalid in empty not-script wrong-shell missing-version malformed-version duplicate-version; do
+  case "$invalid" in
+    empty) : > "$TEST_DIR/candidate" ;;
+    not-script) printf 'VERSION="9.9.9"\n' > "$TEST_DIR/candidate" ;;
+    wrong-shell) printf '#!/bin/sh\nVERSION="9.9.9"\n' > "$TEST_DIR/candidate" ;;
+    missing-version) printf '#!/usr/bin/env bash\necho missing\n' > "$TEST_DIR/candidate" ;;
+    malformed-version) printf '#!/usr/bin/env bash\nVERSION="9..9"\n' > "$TEST_DIR/candidate" ;;
+    duplicate-version) printf '#!/usr/bin/env bash\nVERSION="9.9.9"\nVERSION="1.2.3"\n' > "$TEST_DIR/candidate" ;;
+  esac
+  if "$TEST_DIR/install/tmuxify" --update > "$TEST_DIR/output" 2>&1; then fail "$invalid candidate was accepted"; fi
+  cmp -s "$ROOT_DIR/tmuxify" "$TEST_DIR/install/tmuxify" || fail "$invalid candidate changed the installation"
+  grep -q 'Error:' "$TEST_DIR/output" || fail 'rejection had no error message'
+  [[ -z $(find "$TMPDIR" -mindepth 1 -print) ]] || fail 'rejected update leaked temporary files'
+done
+
+cat > "$TEST_DIR/candidate" <<'SH'
+#!/usr/bin/env bash
+VERSION="9.9.9"
+printf 'candidate executed\n' > "$HOME/candidate-executed"
+SH
+"$TEST_DIR/install/tmuxify" --update > "$TEST_DIR/output"
+cmp -s "$TEST_DIR/candidate" "$TEST_DIR/install/tmuxify" || fail 'valid candidate was not installed'
+[[ -x "$TEST_DIR/install/tmuxify" ]] || fail 'installed candidate is not executable'
+[[ ! -e "$HOME/candidate-executed" ]] || fail 'validation executed the downloaded program'
+[[ -f "$XDG_CONFIG_HOME/tmuxify/layouts/examples/example.yml" ]] || fail 'update omitted examples'
+[[ -f "$XDG_CONFIG_HOME/tmuxify/completions/tmuxify.bash" && -f "$XDG_CONFIG_HOME/tmuxify/completions/_tmuxify" ]] || fail 'update omitted completions'
+grep -q 'version 9.9.9' "$TEST_DIR/output" || fail 'update reported wrong version'
+[[ -z $(find "$TMPDIR" -mindepth 1 -print) ]] || fail 'successful update leaked temporary files'
+echo 'ok - candidate metadata is validated without execution and assets still refresh'
+
+mkdir "$TEST_DIR/bin"
+export TMUXIFY_REAL_MV
+TMUXIFY_REAL_MV=$(command -v mv)
+export TMUXIFY_TEST_INSTALL="$TEST_DIR/install/tmuxify"
+cat > "$TEST_DIR/bin/mv" <<'SH'
+#!/usr/bin/env bash
+if [[ "$2" == "$TMUXIFY_TEST_INSTALL" ]]; then
+  case "$1" in
+    *backup*|*.bak.*)
+      [[ "$TMUXIFY_MOVE_FAILURE" == rollback ]] && exit 1
+      ;;
+    *)
+      if [[ "$TMUXIFY_MOVE_FAILURE" != before ]]; then "$TMUXIFY_REAL_MV" "$@" || exit $?; fi
+      exit 1
+      ;;
+  esac
+fi
+exec "$TMUXIFY_REAL_MV" "$@"
+SH
+chmod +x "$TEST_DIR/bin/mv"
+for failure in before after rollback; do
+  cp "$ROOT_DIR/tmuxify" "$TEST_DIR/install/tmuxify"
+  if PATH="$TEST_DIR/bin:$PATH" TMUXIFY_MOVE_FAILURE="$failure" "$TEST_DIR/install/tmuxify" --update > "$TEST_DIR/output" 2>&1; then
+    fail 'replacement failure unexpectedly succeeded'
+  fi
+  if [[ "$failure" == rollback ]]; then
+    grep -q 'backup retained at' "$TEST_DIR/output" || fail 'failed rollback did not report retained recovery backup'
+    backup=$(find "$TEST_DIR/install" -type f ! -name tmuxify | head -n 1)
+    [[ -n "$backup" ]] || fail 'failed rollback lost the recovery backup'
+    cmp -s "$ROOT_DIR/tmuxify" "$backup" || fail 'failed rollback lost the previous installation'
+    rm "$backup"
+  else
+    cmp -s "$ROOT_DIR/tmuxify" "$TEST_DIR/install/tmuxify" || fail 'replacement failure did not preserve previous installation'
+    [[ $(find "$TEST_DIR/install" -type f | wc -l) -eq 1 ]] || fail 'recoverable failure leaked staging or backup files'
+  fi
+  [[ -z $(find "$TMPDIR" -mindepth 1 -print) ]] || fail 'replacement failure leaked download files'
+done
+echo 'ok - replacement failures recover or explicitly retain the previous installation'
+
+export TMUXIFY_REAL_CHMOD
+TMUXIFY_REAL_CHMOD=$(command -v chmod)
+cat > "$TEST_DIR/bin/chmod" <<'SH'
+#!/usr/bin/env bash
+case "$*" in *.tmuxify-update.*) exit 1 ;; esac
+exec "$TMUXIFY_REAL_CHMOD" "$@"
+SH
+chmod +x "$TEST_DIR/bin/chmod"
+cp "$ROOT_DIR/tmuxify" "$TEST_DIR/install/tmuxify"
+if PATH="$TEST_DIR/bin:$PATH" "$TEST_DIR/install/tmuxify" --update > "$TEST_DIR/output" 2>&1; then
+  fail 'staging permission failure unexpectedly succeeded'
+fi
+cmp -s "$ROOT_DIR/tmuxify" "$TEST_DIR/install/tmuxify" || fail 'staging failure changed installed script'
+[[ $(find "$TEST_DIR/install" -type f | wc -l) -eq 1 ]] || fail 'staging failure leaked install artifacts'
+[[ -z $(find "$TMPDIR" -mindepth 1 -print) ]] || fail 'staging failure leaked download files'
+echo 'ok - executable permissions are prepared before replacement'

--- a/tests/update-test.sh
+++ b/tests/update-test.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+umask 022
 
 ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 TEST_DIR=$(mktemp -d /tmp/tmuxify-update-test.XXXXXX)
@@ -46,6 +47,7 @@ SH
 "$TEST_DIR/install/tmuxify" --update > "$TEST_DIR/output"
 cmp -s "$TEST_DIR/candidate" "$TEST_DIR/install/tmuxify" || fail 'valid candidate was not installed'
 [[ -x "$TEST_DIR/install/tmuxify" ]] || fail 'installed candidate is not executable'
+[[ -n $(find "$TEST_DIR/install/tmuxify" -perm 0755 -print) ]] || fail 'staging changed script readability'
 [[ ! -e "$HOME/candidate-executed" ]] || fail 'validation executed the downloaded program'
 [[ -f "$XDG_CONFIG_HOME/tmuxify/layouts/examples/example.yml" ]] || fail 'update omitted examples'
 [[ -f "$XDG_CONFIG_HOME/tmuxify/completions/tmuxify.bash" && -f "$XDG_CONFIG_HOME/tmuxify/completions/_tmuxify" ]] || fail 'update omitted completions'

--- a/tmuxify
+++ b/tmuxify
@@ -21,6 +21,7 @@ DETACH=0
 RUN_COMMANDS=1
 TMP_DIR=""
 EXPORT_TEMP_FILE=""
+UPDATE_STAGE_FILE=""
 SESSION_CREATED=0
 
 info() { printf '%s\n' "ℹ️ $*"; }
@@ -63,6 +64,9 @@ EOF
 }
 
 cleanup() {
+  if [ -n "$UPDATE_STAGE_FILE" ]; then
+    rm -f "$UPDATE_STAGE_FILE"
+  fi
   if [ -n "$EXPORT_TEMP_FILE" ]; then
     rm -f "$EXPORT_TEMP_FILE"
   fi
@@ -230,6 +234,7 @@ safe_update() {
 
   info "Downloading latest tmuxify..."
   temp_dir=$(mktemp -d 2>/dev/null || mktemp -d -t tmuxify-update) || die "Failed to create temporary directory."
+  TMP_DIR="$temp_dir"
   temp_file="$temp_dir/tmuxify"
   examples_archive="$temp_dir/tmuxify-examples.tar.gz"
   completions_archive="$temp_dir/tmuxify-completions.tar.gz"
@@ -242,16 +247,19 @@ safe_update() {
   [ -s "$temp_file" ] || { rm -rf "$temp_dir"; die "Downloaded file is empty. Update failed."; }
   first_line=$(sed -n '1p' "$temp_file")
   case "$first_line" in
-    '#!'*) ;;
-    *) rm -rf "$temp_dir"; die "Downloaded file does not look executable. Update aborted." ;;
+    '#!/usr/bin/env bash'|'#!/bin/bash') ;;
+    *) rm -rf "$temp_dir"; die "Downloaded candidate must be a Bash script. Update aborted." ;;
   esac
 
-  if ! grep -q '^#!/' "$temp_file" || ! grep -q '^VERSION=' "$temp_file"; then
+  if ! bash -n "$temp_file"; then
     rm -rf "$temp_dir"
-    die "Downloaded candidate failed static validation."
+    die "Downloaded candidate has invalid Bash syntax. Update aborted."
   fi
-  chmod +x "$temp_file" || { rm -rf "$temp_dir"; die "Failed to mark downloaded candidate executable."; }
-  candidate_version=$(sed -n 's/^VERSION="\([0-9][0-9.]*\)"$/\1/p' "$temp_file" | head -n 1)
+  if [ "$(grep -c '^VERSION=' "$temp_file")" != 1 ] || ! grep -Eq '^VERSION="[0-9]+\.[0-9]+\.[0-9]+"$' "$temp_file"; then
+    rm -rf "$temp_dir"
+    die "Downloaded candidate must declare one numeric major.minor.patch VERSION. Update aborted."
+  fi
+  candidate_version=$(sed -n 's/^VERSION="\([0-9.]*\)"$/\1/p' "$temp_file")
   info "Downloading latest example layouts..."
   if ! curl -fsSL "$EXAMPLES_ARCHIVE_URL" -o "$examples_archive"; then
     warn "Failed to download example layouts from $EXAMPLES_ARCHIVE_URL; continuing with script update."
@@ -262,7 +270,6 @@ safe_update() {
     warn "Failed to download completions from $COMPLETIONS_ARCHIVE_URL; continuing with script update."
     completions_archive=""
   fi
-  [ -n "$candidate_version" ] || candidate_version="unknown"
 
   SCRIPT_PATH=$(command -v "$0" 2>/dev/null || printf '%s' "$0")
   INSTALL_DIR=$(dirname "$SCRIPT_PATH")
@@ -273,13 +280,21 @@ safe_update() {
     die "Insufficient permissions to update $INSTALL_PATH. Re-run your package manager update, or install manually after reviewing the release. tmuxify no longer escalates with sudo automatically."
   fi
 
-  backup="$INSTALL_PATH.bak.$$"
+  # Stage alongside the install so the final rename stays on one filesystem.
+  # Set permissions before publishing; a chmod failure must not damage the install.
+  UPDATE_STAGE_FILE=$(mktemp "$INSTALL_DIR/.tmuxify-update.XXXXXX") || die "Failed to stage update beside $INSTALL_PATH."
+  if ! cp "$temp_file" "$UPDATE_STAGE_FILE" || ! chmod +x "$UPDATE_STAGE_FILE"; then
+    die "Failed to prepare executable update."
+  fi
+  backup=""
   if [ -e "$INSTALL_PATH" ]; then
-    cp "$INSTALL_PATH" "$backup" || { rm -rf "$temp_dir"; die "Failed to create update backup."; }
+    backup=$(mktemp "$INSTALL_DIR/.tmuxify-backup.XXXXXX") || die "Failed to prepare update backup."
+    cp -p "$INSTALL_PATH" "$backup" || { rm -f "$backup"; die "Failed to create update backup."; }
   fi
 
-  if mv "$temp_file" "$INSTALL_PATH" && chmod +x "$INSTALL_PATH"; then
-    [ -e "$backup" ] && rm -f "$backup"
+  if mv "$UPDATE_STAGE_FILE" "$INSTALL_PATH"; then
+    UPDATE_STAGE_FILE=""
+    [ -n "$backup" ] && rm -f "$backup"
     mkdir -p "$TMUXIFY_CONFIG_DIR" "$GLOBAL_LAYOUTS_DIR" "$GLOBAL_COMPLETIONS_DIR" || { rm -rf "$temp_dir"; die "Failed to create tmuxify config directories."; }
     if [ -n "$examples_archive" ]; then
       install_example_layouts "$examples_archive" "$temp_dir/examples"
@@ -292,9 +307,13 @@ safe_update() {
     exit 0
   fi
 
-  [ -e "$backup" ] && mv "$backup" "$INSTALL_PATH"
-  rm -rf "$temp_dir"
-  die "Failed to replace installed script; previous version restored."
+  if [ -n "$backup" ]; then
+    if mv "$backup" "$INSTALL_PATH"; then
+      die "Failed to replace installed script; previous version restored."
+    fi
+    die "Failed to replace installed script and restore it; recovery backup retained at $backup. Restore it manually."
+  fi
+  die "Failed to replace installed script."
 }
 
 if [ "${UPDATE_REQUESTED:-0}" -eq 1 ]; then

--- a/tmuxify
+++ b/tmuxify
@@ -64,11 +64,11 @@ EOF
 }
 
 cleanup() {
-  if [ -n "$UPDATE_STAGE_FILE" ]; then
-    rm -f "$UPDATE_STAGE_FILE"
-  fi
   if [ -n "$EXPORT_TEMP_FILE" ]; then
     rm -f "$EXPORT_TEMP_FILE"
+  fi
+  if [ -n "$UPDATE_STAGE_FILE" ]; then
+    rm -f "$UPDATE_STAGE_FILE"
   fi
   if [ -n "$TMP_DIR" ] && [ -d "$TMP_DIR" ]; then
     rm -rf "$TMP_DIR"
@@ -283,7 +283,7 @@ safe_update() {
   # Stage alongside the install so the final rename stays on one filesystem.
   # Set permissions before publishing; a chmod failure must not damage the install.
   UPDATE_STAGE_FILE=$(mktemp "$INSTALL_DIR/.tmuxify-update.XXXXXX") || die "Failed to stage update beside $INSTALL_PATH."
-  if ! cp "$temp_file" "$UPDATE_STAGE_FILE" || ! chmod +x "$UPDATE_STAGE_FILE"; then
+  if ! cp -p "$temp_file" "$UPDATE_STAGE_FILE" || ! chmod +x "$UPDATE_STAGE_FILE"; then
     die "Failed to prepare executable update."
   fi
   backup=""


### PR DESCRIPTION
## Summary

- Reject invalid Bash shebangs/syntax and missing, malformed, or duplicate numeric version declarations before replacement, without executing downloaded code.
- Stage the executable candidate beside the install for a same-filesystem rename, preserving script readability rather than inheriting mktemp's owner-only permissions.
- Restore the previous installation on replacement failure; if restoration also fails, retain the recovery backup and report its path accurately.
- Keep example/completion refreshes and the existing no-sudo policy. Document the difference between format validation and authenticity guarantees.

Closes #16

## Verification

- Offline public-CLI tests reproduce invalid-syntax installation and failed-rollback reporting before the fixes.
- `bash tests/update-test.sh` passes on Bash 5.3 and an actual locally built Bash 3.2 interpreter.
- Tests cover empty/malformed candidates, version metadata, non-execution of candidates, successful script/asset installation, readable executable permissions, failures before/after replacement, failed recovery with retained backup, and staging permission failures.
- Full `bash tests/run.sh` passes in an isolated tmux environment, including the original 20 checks and focused updater regressions.
- ShellCheck 0.11.0 and individual Bash 3.2/current-Bash syntax checks pass.

## Review

Reviewed against `15db7bc` on two axes (separate self-review passes; no subagent tool available):

- **Standards:** no remaining findings; changes stay in the existing updater and cleanup boundary with portable shell operations.
- **Spec:** no remaining findings against #16. Review found that mktemp staging removed other users' read access; a regression failed with mode 0711 before the fix and now verifies the intended readable executable mode.

## Integration / scope

Independently based on `main`. All three reliability PR branches merged cleanly in a temporary integration worktree and the combined full suite passed. Pinned-release distribution, signing infrastructure, source URL changes, and privilege escalation remain out of scope.
