### PR TITLE
Support Bash 3.2 completion and test the advertised baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,17 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install dependencies
         run: |
@@ -29,6 +34,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Exercise completion on the advertised Bash baseline
         shell: /bin/bash {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,20 @@ jobs:
           sudo chmod +x /usr/local/bin/yq
 
       - name: ShellCheck
-        run: shellcheck tmuxify
+        run: shellcheck tmuxify completions/tmuxify.bash tests/*.sh
 
       - name: Run integration tests
         run: tests/run.sh
+
+  completion-bash32:
+    runs-on: macos-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Exercise completion on the advertised Bash baseline
+        shell: /bin/bash {0}
+        run: |
+          test "${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]}" = 3.2
+          /bin/bash -n tmuxify completions/tmuxify.bash
+          /bin/bash tests/completion-test.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,5 +34,5 @@ jobs:
         shell: /bin/bash {0}
         run: |
           test "${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]}" = 3.2
-          /bin/bash -n tmuxify completions/tmuxify.bash
+          /bin/bash -n tmuxify
           /bin/bash tests/completion-test.sh

--- a/completions/tmuxify.bash
+++ b/completions/tmuxify.bash
@@ -13,7 +13,7 @@ _tmuxify_file_options() {
 }
 
 _tmuxify() {
-  local cur prev opts file_opts
+  local cur prev opts file_opts candidate
   COMPREPLY=()
   cur=${COMP_WORDS[COMP_CWORD]}
   prev=${COMP_WORDS[COMP_CWORD-1]}
@@ -21,12 +21,16 @@ _tmuxify() {
   file_opts=$(_tmuxify_file_options)
 
   if printf '%s\n' "$file_opts" | grep -Fxq -- "$prev"; then
-    mapfile -t COMPREPLY < <(compgen -f -- "$cur")
+    while IFS= read -r candidate; do
+      COMPREPLY+=("$candidate")
+    done < <(compgen -f -- "$cur")
     return 0
   fi
 
   if [[ $cur == -* ]]; then
-    mapfile -t COMPREPLY < <(compgen -W "$opts" -- "$cur")
+    while IFS= read -r candidate; do
+      COMPREPLY+=("$candidate")
+    done < <(compgen -W "$opts" -- "$cur")
   fi
 }
 

--- a/doc/development.md
+++ b/doc/development.md
@@ -23,11 +23,13 @@ bash -n tmuxify
 Run static analysis and the full integration suite when local dependencies are available:
 
 ```bash
-shellcheck tmuxify tests/run.sh
+shellcheck tmuxify completions/tmuxify.bash tests/*.sh
 bash tests/run.sh
 ```
 
 ShellCheck should pass without behavior-changing rewrites. If a deliberate `bash -c` string must defer expansion to the child shell, use the narrowest inline suppression and document why rather than broad suppression.
+
+Focused regression scripts named `tests/*-test.sh` can also be run individually; the full suite discovers them automatically. Completion behavior is tested on current Bash and on the advertised Bash 3.2 baseline in macOS CI. On macOS, run `/bin/bash tests/completion-test.sh` to check the system Bash directly; completion tests need neither tmux nor yq.
 
 The script itself needs Bash, tmux, and Mike Farah `yq` v4. Some tests may stub dependencies, but installing the real tools is best for end-to-end checks.
 

--- a/tests/completion-test.sh
+++ b/tests/completion-test.sh
@@ -5,7 +5,7 @@ ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 TEST_DIR=$(mktemp -d)
 trap 'rm -rf "$TEST_DIR"' EXIT
 export PATH="$ROOT_DIR:$PATH"
-# shellcheck source=../completions/tmuxify.bash
+# shellcheck source=completions/tmuxify.bash
 source "$ROOT_DIR/completions/tmuxify.bash"
 fail() { printf 'not ok - %s\n' "$*" >&2; exit 1; }
 

--- a/tests/completion-test.sh
+++ b/tests/completion-test.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+TEST_DIR=$(mktemp -d)
+trap 'rm -rf "$TEST_DIR"' EXIT
+export PATH="$ROOT_DIR:$PATH"
+# shellcheck source=../completions/tmuxify.bash
+source "$ROOT_DIR/completions/tmuxify.bash"
+fail() { printf 'not ok - %s\n' "$*" >&2; exit 1; }
+
+COMP_WORDS=(tmuxify --dr)
+COMP_CWORD=1
+_tmuxify
+[[ ${COMPREPLY[*]:-} == --dry-run ]] || fail 'option completion failed'
+echo "ok - option completion works on Bash $BASH_VERSION"
+
+COMP_WORDS=(tmuxify -)
+COMP_CWORD=1
+_tmuxify
+candidates=$(printf '%s\n' "${COMPREPLY[@]}")
+while IFS= read -r option; do
+  grep -Fxq -- "$option" <<< "$candidates" || fail "missing metadata option $option"
+done < <(tmuxify --completion-options | tr '|:' '\n' | grep '^-')
+echo 'ok - completion includes the CLI metadata options and aliases'
+
+cd "$TEST_DIR"
+touch 'layout with spaces.yml' 'layout-other.yaml'
+for flag in --file -f --export -e; do
+  COMP_WORDS=(tmuxify "$flag" 'layout w')
+  COMP_CWORD=2
+  _tmuxify
+  [[ ${#COMPREPLY[@]} -eq 1 && ${COMPREPLY[0]} == 'layout with spaces.yml' ]] || fail "$flag split or lost a spaced filename"
+
+  COMP_WORDS=(tmuxify --detach "$flag" layout)
+  COMP_CWORD=3
+  _tmuxify
+  [[ ${#COMPREPLY[@]} -eq 2 ]] || fail "$flag did not complete at a later cursor position"
+done
+echo 'ok - long and short file options preserve filenames containing spaces'
+
+COMP_WORDS=(tmuxify --file missing)
+COMP_CWORD=2
+_tmuxify
+[[ -z ${COMPREPLY[*]:-} ]] || fail 'unmatched filename retained stale candidates'
+COMP_WORDS=(tmuxify --does-not-exist)
+COMP_CWORD=1
+_tmuxify
+[[ -z ${COMPREPLY[*]:-} ]] || fail 'unmatched option retained stale candidates'
+COMP_WORDS=(tmuxify '')
+COMP_CWORD=1
+_tmuxify
+[[ -z ${COMPREPLY[*]:-} ]] || fail 'empty argument retained stale candidates'
+echo 'ok - unmatched and empty arguments reset completion candidates'

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -515,3 +515,9 @@ run_expect_success "$TMUXIFY" --dry-run --file "$single_export_file" >/dev/null
 [[ "$(yq -r '.session.name' "$single_export_file")" == "$single_export_session" ]] || fail "expected YAML-significant session name to round trip"
 [[ "$(yq -r '.windows | length' "$single_export_file")" == "1" && "$(yq -r '.windows[0].layout.splits | length' "$single_export_file")" == "1" ]] || fail "expected one-window one-pane export"
 echo "ok 20 - export preserves all windows, pane structure, active focus, YAML names, and file protections"
+
+# Focused public-boundary regressions can also be run independently.
+for test_file in "$ROOT_DIR"/tests/*-test.sh; do
+  [[ -f "$test_file" ]] || continue
+  bash "$test_file"
+done

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -51,7 +51,13 @@ run_expect_failure() {
   printf '%s' "$output"
 }
 
-echo "1..20"
+test_number=20
+test_count=$test_number
+for test_file in "$ROOT_DIR"/tests/*-test.sh; do
+  [[ -f "$test_file" ]] || continue
+  test_count=$((test_count + 1))
+done
+echo "1..$test_count"
 
 output=$(run_expect_success "$TMUXIFY" --help)
 assert_contains "$output" "--dry-run"
@@ -519,5 +525,11 @@ echo "ok 20 - export preserves all windows, pane structure, active focus, YAML n
 # Focused public-boundary regressions can also be run independently.
 for test_file in "$ROOT_DIR"/tests/*-test.sh; do
   [[ -f "$test_file" ]] || continue
-  bash "$test_file"
+  test_number=$((test_number + 1))
+  if bash "$test_file" 2>&1 | sed 's/^/# /'; then
+    echo "ok $test_number - ${test_file##*/}"
+  else
+    echo "not ok $test_number - ${test_file##*/}"
+    exit 1
+  fi
 done


### PR DESCRIPTION
## Summary

- Replace Bash-4-only mapfile calls with Bash-3.2-compatible read loops while preserving filenames containing spaces.
- Exercise actual option/file completion behavior, aliases, CLI metadata coverage, later cursor positions, and stale-candidate clearing.
- Add a small macOS CI job explicitly using system Bash 3.2; expand ShellCheck coverage to completion and test scripts.
- Discover focused regression scripts from the existing full-suite entry point, while keeping each script independently runnable.

Closes #17

## Verification

- Confirmed the new test fails with `mapfile: command not found` on Bash 3.2 before the fix.
- `bash tests/completion-test.sh` passes on Bash 5.3 and actual GNU Bash 3.2.0 built locally; the CLI metadata command also ran through Bash 3.2 during baseline verification.
- Full `bash tests/run.sh` passes in an isolated tmux environment, including all original 20 checks and focused completion behavior tests.
- ShellCheck 0.11.0 and individual Bash 3.2/current-Bash syntax checks pass.
- macOS-specific execution is delegated to the new GitHub Actions job; local validation used Linux with actual Bash 3.2, not a simulated version.

## Review

Reviewed against `15db7bc` on two axes (separate self-review passes; no subagent tool available):

- **Standards:** no remaining findings. Portable quoted array appends preserve completion candidates without adding a runtime dependency.
- **Spec:** no remaining findings against #17. The minimum Bash version is unchanged; option metadata remains the source of truth and Zsh completion is untouched.

## Integration / scope

Independently based on `main`. All three reliability PR branches merged cleanly in a temporary integration worktree and the combined full suite passed. No additional completion framework or broad OS matrix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bash completion compatibility, including support for Bash 3.2 on macOS.
  * Preserved completion behavior for filenames with spaces, options, aliases, and later cursor positions.
  * Prevented stale completion suggestions when input does not match available files or options.

* **Tests**
  * Added comprehensive automated tests for Bash completion behavior.
  * Expanded validation to cover completion scripts and focused regression tests across supported environments.

* **Documentation**
  * Documented how to run focused regression and completion tests independently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->